### PR TITLE
fix(WebGL): Gracefully fail on missing WebGL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
         <link href="css/style.css" rel="stylesheet" type="text/css"></link>
         <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous"></script>
         <script src="js/three.js"></script>
+        <script src="js/WebGL.js"></script>
         <script src="js/stats.min.js"></script>
         <script src="js/STLLoader.js"></script>
         <script src="js/OrbitControls.js"></script>
@@ -34,6 +35,7 @@
             </div>
         </div>
         <div class="content">
+            <div id="error-container"></div>
             <div id="viewer">
                 <canvas id="viewer_canvas"></canvas>
                 <div id="banner">Click to rotate. Scroll to zoom.</div>

--- a/docs/js/WebGL.js
+++ b/docs/js/WebGL.js
@@ -1,0 +1,94 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ * @author mr.doob / http://mrdoob.com/
+ */
+
+var WEBGL = {
+
+	isWebGLAvailable: function () {
+
+		try {
+
+			var canvas = document.createElement( 'canvas' );
+			return !! ( window.WebGLRenderingContext && ( canvas.getContext( 'webgl' ) || canvas.getContext( 'experimental-webgl' ) ) );
+
+		} catch ( e ) {
+
+			return false;
+
+		}
+
+	},
+
+	isWebGL2Available: function () {
+
+		try {
+
+			var canvas = document.createElement( 'canvas' );
+			return !! ( window.WebGL2RenderingContext && canvas.getContext( 'webgl2' ) );
+
+		} catch ( e ) {
+
+			return false;
+
+		}
+
+	},
+
+	getWebGLErrorMessage: function () {
+
+		return this.getErrorMessage( 1 );
+
+	},
+
+	getWebGL2ErrorMessage: function () {
+
+		return this.getErrorMessage( 2 );
+
+	},
+
+	getErrorMessage: function ( version ) {
+
+		var names = {
+			1: 'WebGL',
+			2: 'WebGL 2'
+		};
+
+		var contexts = {
+			1: window.WebGLRenderingContext,
+			2: window.WebGL2RenderingContext
+		};
+
+		var message = 'Your $0 does not seem to support <a href="http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation" style="color:#000">$1</a>';
+
+		var element = document.createElement( 'div' );
+		element.id = 'webglmessage';
+		element.style.fontFamily = 'monospace';
+		element.style.fontSize = '13px';
+		element.style.fontWeight = 'normal';
+		element.style.textAlign = 'center';
+		element.style.background = '#fff';
+		element.style.color = '#000';
+		element.style.padding = '1.5em';
+		element.style.width = '400px';
+		element.style.margin = '5em auto 0';
+
+		if ( contexts[ version ] ) {
+
+			message = message.replace( '$0', 'graphics card' );
+
+		} else {
+
+			message = message.replace( '$0', 'browser' );
+
+		}
+
+		message = message.replace( '$1', names[ version ] );
+
+		element.innerHTML = message;
+
+		return element;
+
+	}
+
+};

--- a/docs/js/viewer.js
+++ b/docs/js/viewer.js
@@ -7,143 +7,149 @@ var model_base_url = 'https://s3.amazonaws.com/splitflap-travis/branches/master/
 
 var debug = false;
 
+var viewer_canvas = document.getElementById("error-container");
 var canvas = document.getElementById("viewer_canvas");
 
-var scene = new THREE.Scene();
-var render_width = canvas.clientWidth;
-var render_height = canvas.clientHeight;
+if (WEBGL.isWebGLAvailable()) {
+  var scene = new THREE.Scene();
+  var render_width = canvas.clientWidth;
+  var render_height = canvas.clientHeight;
 
-scene.fog = new THREE.Fog(0x985F6F, 1200, 4000);
-var camera = new THREE.PerspectiveCamera( 35, render_width/render_height, 1, 4000 );
-camera.position.set(-400, 200, -400);
+  scene.fog = new THREE.Fog(0x985F6F, 1200, 4000);
+  var camera = new THREE.PerspectiveCamera( 35, render_width/render_height, 1, 4000 );
+  camera.position.set(-400, 200, -400);
 
-var renderer = new THREE.WebGLRenderer({canvas: canvas});
+  var renderer = new THREE.WebGLRenderer({canvas: canvas});
 
-function addShadowedLight(x, y, z, color, intensity, top, right, bottom, left) {
-    var directionalLight = new THREE.DirectionalLight( color, intensity );
-    directionalLight.position.set( x, y, z );
-    scene.add( directionalLight );
-    directionalLight.castShadow = true;
-    directionalLight.shadow.camera.left = left;
-    directionalLight.shadow.camera.right = right;
-    directionalLight.shadow.camera.top = top;
-    directionalLight.shadow.camera.bottom = bottom;
-    directionalLight.shadow.camera.near = 1200;
-    directionalLight.shadow.camera.far = 1700;
-    directionalLight.shadow.mapSize.width = 512;
-    directionalLight.shadow.mapSize.height = 512;
+  function addShadowedLight(x, y, z, color, intensity, top, right, bottom, left) {
+      var directionalLight = new THREE.DirectionalLight( color, intensity );
+      directionalLight.position.set( x, y, z );
+      scene.add( directionalLight );
+      directionalLight.castShadow = true;
+      directionalLight.shadow.camera.left = left;
+      directionalLight.shadow.camera.right = right;
+      directionalLight.shadow.camera.top = top;
+      directionalLight.shadow.camera.bottom = bottom;
+      directionalLight.shadow.camera.near = 1200;
+      directionalLight.shadow.camera.far = 1700;
+      directionalLight.shadow.mapSize.width = 512;
+      directionalLight.shadow.mapSize.height = 512;
 
-    if (debug) {
-        scene.add( new THREE.CameraHelper( directionalLight.shadow.camera ));
-    }
-}
+      if (debug) {
+          scene.add( new THREE.CameraHelper( directionalLight.shadow.camera ));
+      }
+  }
 
-// Ground
-var plane = new THREE.Mesh(
-    new THREE.PlaneBufferGeometry(7000, 7000),
-    new THREE.MeshPhongMaterial({color: 0x231A22, specular:0x101010})
-);
-plane.rotation.x = -Math.PI/2;
-plane.position.y = -0.1;
-plane.receiveShadow = true;
-scene.add(plane);
+  // Ground
+  var plane = new THREE.Mesh(
+      new THREE.PlaneBufferGeometry(7000, 7000),
+      new THREE.MeshPhongMaterial({color: 0x231A22, specular:0x101010})
+  );
+  plane.rotation.x = -Math.PI/2;
+  plane.position.y = -0.1;
+  plane.receiveShadow = true;
+  scene.add(plane);
 
-// Lights
-scene.add( new THREE.HemisphereLight( 0x443333, 0x111122 ) );
-addShadowedLight( 300, 1000, -1000, 0xE6CBE9, 0.9, 150, 100, -50, -100);
-addShadowedLight( -300, 1500, -100, 0xF6F1C0, 0.6, 100, 80, -80, -80);
+  // Lights
+  scene.add( new THREE.HemisphereLight( 0x443333, 0x111122 ) );
+  addShadowedLight( 300, 1000, -1000, 0xE6CBE9, 0.9, 150, 100, -50, -100);
+  addShadowedLight( -300, 1500, -100, 0xF6F1C0, 0.6, 100, 80, -80, -80);
 
-// renderer
-renderer.setSize( render_width, render_height);
-renderer.setClearColor( scene.fog.color );
-renderer.setPixelRatio( window.devicePixelRatio );
-renderer.gammaInput = true;
-renderer.gammaOutput = true;
-renderer.shadowMap.enabled = true;
+  // renderer
+  renderer.setSize( render_width, render_height);
+  renderer.setClearColor( scene.fog.color );
+  renderer.setPixelRatio( window.devicePixelRatio );
+  renderer.gammaInput = true;
+  renderer.gammaOutput = true;
+  renderer.shadowMap.enabled = true;
 
-if (debug) {
-    var stats = new Stats();
-    stats.showPanel( 0 );
-    document.body.appendChild( stats.dom );
-}
+  if (debug) {
+      var stats = new Stats();
+      stats.showPanel( 0 );
+      document.body.appendChild( stats.dom );
+  }
 
-var render = function () {
-    if (debug) {
-        stats.begin();
-    }
+  var render = function () {
+      if (debug) {
+          stats.begin();
+      }
 
-    controls.update();
-    renderer.render(scene, camera);
+      controls.update();
+      renderer.render(scene, camera);
 
-    if (debug) {
-        stats.end();
-    }
-    requestAnimationFrame(render);
-};
+      if (debug) {
+          stats.end();
+      }
+      requestAnimationFrame(render);
+  };
 
-// Camera Controls
-controls = new THREE.OrbitControls( camera, renderer.domElement );
-controls.enableZoom = true;
-controls.minDistance = 80;
-controls.maxDistance = 1300;
-controls.validUpdate = function(position, quaternion, target) {
-    // Don't allow camera to go below ground
-    return position.y > 0 && target.y > 0;
-};
-controls.autoRotateSpeed = 1.5;
-controls.addEventListener('start', function(){
-  controls.autoRotate = false;
-  $("#banner").fadeOut();
-});
+  // Camera Controls
+  controls = new THREE.OrbitControls( camera, renderer.domElement );
+  controls.enableZoom = true;
+  controls.minDistance = 80;
+  controls.maxDistance = 1300;
+  controls.validUpdate = function(position, quaternion, target) {
+      // Don't allow camera to go below ground
+      return position.y > 0 && target.y > 0;
+  };
+  controls.autoRotateSpeed = 1.5;
+  controls.addEventListener('start', function(){
+    controls.autoRotate = false;
+    $("#banner").fadeOut();
+  });
 
 
-var cameraTarget = new THREE.Vector3(0, enclosure_height_lower, 0);
-controls.target = cameraTarget;
-controls.update();
+  var cameraTarget = new THREE.Vector3(0, enclosure_height_lower, 0);
+  controls.target = cameraTarget;
+  controls.update();
 
-render();
+  render();
 
-var expected_models = 0;
-var loaded_models = 0;
-var loader = new THREE.XHRLoader(THREE.DefaultLoadingManager);
-loader.load(model_base_url + 'manifest.json', function(text) {
-    var json = JSON.parse(text);
-    var keys = Object.keys(json)
-    expected_models = keys.length;
-    for (var i = 0; i < expected_models; i++) {
-        var color = json[keys[i]];
-        loadStl(model_base_url + keys[i], new THREE.Color( color[0], color[1], color[2] ).getHex());
-    }
-});
-var loadStl = function(url, color) {
-    var loader = new THREE.STLLoader();
-    loader.load(url, function(geometry) {
-        var material = new THREE.MeshPhongMaterial({
-            color: color,
-            specular: 0x111111,
-            shininess: 10
-        });
-        var mesh = new THREE.Mesh(geometry, material);
+  var expected_models = 0;
+  var loaded_models = 0;
+  var loader = new THREE.XHRLoader(THREE.DefaultLoadingManager);
+  loader.load(model_base_url + 'manifest.json', function(text) {
+      var json = JSON.parse(text);
+      var keys = Object.keys(json)
+      expected_models = keys.length;
+      for (var i = 0; i < expected_models; i++) {
+          var color = json[keys[i]];
+          loadStl(model_base_url + keys[i], new THREE.Color( color[0], color[1], color[2] ).getHex());
+      }
+  });
+  var loadStl = function(url, color) {
+      var loader = new THREE.STLLoader();
+      loader.load(url, function(geometry) {
+          var material = new THREE.MeshPhongMaterial({
+              color: color,
+              specular: 0x111111,
+              shininess: 10
+          });
+          var mesh = new THREE.Mesh(geometry, material);
 
-        mesh.position.set(0, enclosure_height_lower, 0);
-        mesh.rotation.set(-Math.PI/2, 0, 0);
+          mesh.position.set(0, enclosure_height_lower, 0);
+          mesh.rotation.set(-Math.PI/2, 0, 0);
 
-        mesh.castShadow = true;
-        mesh.receiveShadow = true;
-        scene.add(mesh);
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
+          scene.add(mesh);
 
-        loaded_models++;
-        if (loaded_models === expected_models) {
-            controls.autoRotate = true;
-            $("#banner").fadeIn(1200);
-        }
-    });
-};
+          loaded_models++;
+          if (loaded_models === expected_models) {
+              controls.autoRotate = true;
+              $("#banner").fadeIn(1200);
+          }
+      });
+  };
 
-if (canvas.classList.contains("embed")) {
-    window.addEventListener('resize', function () {
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        camera.aspect = window.innerWidth / window.innerHeight;
-        camera.updateProjectionMatrix();
-    });
+  if (canvas.classList.contains("embed")) {
+      window.addEventListener('resize', function () {
+          renderer.setSize(window.innerWidth, window.innerHeight);
+          camera.aspect = window.innerWidth / window.innerHeight;
+          camera.updateProjectionMatrix();
+      });
+  }
+} else {
+    var warning = WEBGL.getWebGLErrorMessage();
+    viewer_canvas.appendChild(warning);
 }


### PR DESCRIPTION
Amazing project @scottbez1! I stumbled across it when looking for a way to build my own splitflap (after seeing how crazy expensive the few mass produced ones are).

This is just a small PR fail gracefully and show an error when a user doesn't support WebGL (which apparently I don't in chrome, but I do on safari).

Here's a gif showing the two experiences (WebGL supported in safari on the left, WebGL not supported in chrome on the right)

![gif demo](https://dl.dropboxusercontent.com/s/m5eld0486wc0pie/2018-09-27%2020.02.39.gif?dl=0)


