### PR TITLE
add rotation offset option in splitflap module

### DIFF
--- a/arduino/splitflap/splitflap_module.h
+++ b/arduino/splitflap/splitflap_module.h
@@ -99,6 +99,7 @@ class SplitflapModule {
   uint8_t target_flap_index = 0;
 
   // Current position/destination. Numbers are modulo GEAR_RATIO_INPUT_STEPS
+  const uint32_t offset_steps;
   uint32_t current_step = 0;
   uint32_t delta_steps = 0;
 
@@ -131,7 +132,8 @@ class SplitflapModule {
     uint8_t &motor_out,
     const uint8_t motor_bitshift,
     uint8_t &sensor_in,
-    const uint8_t sensor_bitmask
+    const uint8_t sensor_bitmask,
+    const uint8_t offset_steps
   );
 
 #if HOME_CALIBRATION_ENABLED
@@ -178,11 +180,13 @@ SplitflapModule::SplitflapModule(
   uint8_t &motor_out,
   const uint8_t motor_bitshift,
   uint8_t &sensor_in,
-  const uint8_t sensor_bitmask) :
+  const uint8_t sensor_bitmask,
+  const uint8_t offset_steps = 0) :
     motor_out(motor_out),
     motor_bitshift(motor_bitshift),
     sensor_in(sensor_in),
-    sensor_bitmask(sensor_bitmask)
+    sensor_bitmask(sensor_bitmask),
+    offset_steps(offset_steps)
 {
 }
 
@@ -273,7 +277,7 @@ inline uint32_t SplitflapModule::GetTargetStepForFlapIndex(uint32_t from_step, u
 
 __attribute__((always_inline))
 inline void SplitflapModule::GoToTargetFlapIndex() {
-    delta_steps = GetTargetStepForFlapIndex(current_step, target_flap_index) - current_step;
+    delta_steps = GetTargetStepForFlapIndex(current_step, target_flap_index) - current_step + offset_steps;
 
 
 #if VERBOSE_LOGGING


### PR DESCRIPTION
Hi,

While installing my flap screen, I had an issue with flaps being just about to flip but still stuck upward. Thus sometimes I had wrong letters displayed. Instead of fixing the front case itself I found more convenient to add an offset option when you declare a module. With this option I have been able to tweak the rotation so every flap do correctly flap when needed :)

```c++
// Last argument is the optional offset_steps value
SplitflapModule moduleA((uint8_t&)PORTD, 4, (uint8_t&)PINB, B00010000, 10); 
```


Remark: Consider testing it on your screen before merging, I cleaned the code and added a default value but I don't have my screen to test the final code (even if with the few modifications I think it's quite safe...).