### PR TITLE
Migrate to platformio with Arduino IDE compatibility

### DIFF
--- a/arduino/splitflap/.gitignore
+++ b/arduino/splitflap/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/arduino/splitflap/.travis.yml
+++ b/arduino/splitflap/.travis.yml
@@ -1,0 +1,67 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < https://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < https://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < https://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choose one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# install:
+#     - pip install -U platformio
+#     - platformio update
+#
+# script:
+#     - platformio run
+
+
+#
+# Template #2: The project is intended to be used as a library with examples.
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# env:
+#     - PLATFORMIO_CI_SRC=path/to/test/file.c
+#     - PLATFORMIO_CI_SRC=examples/file.ino
+#     - PLATFORMIO_CI_SRC=path/to/test/directory
+#
+# install:
+#     - pip install -U platformio
+#     - platformio update
+#
+# script:
+#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N

--- a/arduino/splitflap/.vscode/extensions.json
+++ b/arduino/splitflap/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2016 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
+#include <Arduino.h>
 
 /***** CONFIGURATION *****/
 
@@ -73,6 +75,7 @@ uint32_t color_orange = strip.Color(30, 7, 0);
 BluetoothSerial SerialBT;
 #endif
 
+void dump_status(void);
 
 void setup() {
   Serial.begin(38400);
@@ -296,7 +299,7 @@ void loop() {
     run_iteration();
 #endif
 
-    #ifdef ESP8266 || defined(ESP32)
+    #if defined(ESP8266) || defined(ESP32)
     // Yield to avoid triggering Soft WDT
     yield();
     #endif

--- a/arduino/splitflap/Splitflap/acceleration.h
+++ b/arduino/splitflap/Splitflap/acceleration.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/arduino/splitflap/Splitflap/basic_io_config.h
+++ b/arduino/splitflap/Splitflap/basic_io_config.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2018 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/arduino/splitflap/Splitflap/generate_acceleration.py
+++ b/arduino/splitflap/Splitflap/generate_acceleration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#   Copyright 2017 Scott Bezek and the splitflap contributors
+#   Copyright 2020 Scott Bezek and the splitflap contributors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ ACCEL_TIME_MICROS = 200000
 IDLE_PERIOD_MICROS = 1200
 
 _TEMPLATE = """/*
-   Copyright 2017 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/arduino/splitflap/Splitflap/spi_io_config.h
+++ b/arduino/splitflap/Splitflap/spi_io_config.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2018 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/arduino/splitflap/Splitflap/splitflap_module.h
+++ b/arduino/splitflap/Splitflap/splitflap_module.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2018 Scott Bezek and the splitflap contributors
+   Copyright 2020 Scott Bezek and the splitflap contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/arduino/splitflap/include/README
+++ b/arduino/splitflap/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/arduino/splitflap/lib/README
+++ b/arduino/splitflap/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/arduino/splitflap/platformio.ini
+++ b/arduino/splitflap/platformio.ini
@@ -1,0 +1,22 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = Splitflap
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+monitor_speed = 38400
+monitor_flags = --echo
+
+lib_deps =
+    Adafruit NeoPixel@^1.3.5

--- a/arduino/splitflap/test/README
+++ b/arduino/splitflap/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html


### PR DESCRIPTION
PlatformIO offers library management and a lot more powerful development tools. This migrates the project to support PlatformIO without breaking Arduino IDE compatibility for those that are more familiar with Arduino.