### PR TITLE
Improve generate_2d.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - ./3d/scripts/dependencies.sh
 - travis_wait ./electronics/scripts/dependencies.sh
 script:
-- (cd 3d && xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python -u generate_2d.py)
+- (cd 3d && xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python -u generate_2d.py --render-raster)
 - (cd 3d && xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python -u generate_gif.py)
 - python -u 3d/generate_stl.py
 # Control board

--- a/3d/generate_2d.py
+++ b/3d/generate_2d.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#   Copyright 2015-2016 Scott Bezek and the splitflap contributors
+#   Copyright 2015-2020 Scott Bezek and the splitflap contributors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import sys
 from svg_processor import SvgProcessor
 from projection_renderer import Renderer
 
-repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+script_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(script_dir)
 sys.path.append(repo_root)
 
 from util import rev_info
@@ -39,10 +40,12 @@ if __name__ == '__main__':
     parser.add_argument('--panelize', type=int, default=1, help='Quantity to panelize - must be 1 or an even number')
     parser.add_argument('--skip-optimize', action='store_true', help='Don\'t remove redundant/overlapping cut lines')
     parser.add_argument('--kerf', type=float, help='Override kerf_width value')
+    parser.add_argument('--render-raster', action='store_true', help='Render raster PNG from the output SVG (requires '
+                                                                     'Inkscape)')
 
     args = parser.parse_args()
 
-    laser_parts_directory = os.path.join('build', 'laser_parts')
+    laser_parts_directory = os.path.join(script_dir, 'build', 'laser_parts')
 
     extra_variables = {
         'render_revision': rev_info.git_short_rev(),
@@ -51,7 +54,7 @@ if __name__ == '__main__':
     if args.kerf is not None:
         extra_variables['kerf_width'] = args.kerf
 
-    renderer = Renderer('splitflap.scad', laser_parts_directory, extra_variables)
+    renderer = Renderer(os.path.join(script_dir, 'splitflap.scad'), laser_parts_directory, extra_variables)
     renderer.clean()
     svg_output = renderer.render_svgs(panelize_quantity=args.panelize)
 
@@ -64,32 +67,35 @@ if __name__ == '__main__':
 
     processor.write(svg_output)
 
-    # Export to png
-    logging.info('Generating raster preview')
-    raster_svg = os.path.join(laser_parts_directory, 'raster.svg')
-    raster_png = os.path.join(laser_parts_directory, 'raster.png')
-    processor.apply_raster_render_style()
+    logging.info('\n\n\nDone rendering to SVG: ' + svg_output)
 
-    if not args.skip_optimize:
-        # Show which redundant lines were removed and lines merged
-        processor.add_highlight_lines(redundant_lines, '#ff0000')
-        processor.add_highlight_lines(merged_lines, '#0000ff')
+    if args.render_raster:
+        # Export to png
+        logging.info('Generating raster preview')
+        raster_svg = os.path.join(laser_parts_directory, 'raster.svg')
+        raster_png = os.path.join(laser_parts_directory, 'raster.png')
+        processor.apply_raster_render_style()
 
-    processor.write(raster_svg)
+        if not args.skip_optimize:
+            # Show which redundant lines were removed and lines merged
+            processor.add_highlight_lines(redundant_lines, '#ff0000')
+            processor.add_highlight_lines(merged_lines, '#0000ff')
 
-    logging.info('Resize SVG canvas')
-    subprocess.check_call([
-        'inkscape',
-        '--verb=FitCanvasToDrawing',
-        '--verb=FileSave',
-        '--verb=FileClose',
-        raster_svg,
-    ])
-    logging.info('Export PNG')
-    subprocess.check_call([
-        'inkscape',
-        '--export-width=320',
-        '--export-png', raster_png,
-        raster_svg,
-    ])
+        processor.write(raster_svg)
+
+        logging.info('Resize SVG canvas')
+        subprocess.check_call([
+            'inkscape',
+            '--verb=FitCanvasToDrawing',
+            '--verb=FileSave',
+            '--verb=FileClose',
+            raster_svg,
+        ])
+        logging.info('Export PNG')
+        subprocess.check_call([
+            'inkscape',
+            '--export-width=320',
+            '--export-png', raster_png,
+            raster_svg,
+        ])
 

--- a/3d/openscad.py
+++ b/3d/openscad.py
@@ -1,4 +1,4 @@
-#   Copyright 2015-2016 Scott Bezek and the splitflap contributors
+#   Copyright 2015-2020 Scott Bezek and the splitflap contributors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -87,9 +87,16 @@ def run(
 
     stdout_type = subprocess.PIPE if capture_output else None
     stderr_type = subprocess.PIPE if capture_output else None
-    proc = subprocess.Popen(command, stdout=stdout_type, stderr=stderr_type)
-    stdout, stderr = proc.communicate()
-    returncode = proc.returncode
+    try:
+        proc = subprocess.Popen(command, stdout=stdout_type, stderr=stderr_type)
+        stdout, stderr = proc.communicate()
+        returncode = proc.returncode
+    except OSError as e:
+        if 'No such file or directory' in e.strerror:
+            raise RuntimeError('Could not find openscad! Make sure you\'ve installed OpenSCAD and it\'s on your PATH '
+                               'environment variable')
+        else:
+            raise
 
     logger.debug('returncode:%d', returncode)
     if returncode != 0:


### PR DESCRIPTION
Skip rendering raster images by default (only really used for Travis build to generate images for the README).

Added a better error message if you don't have openscad installed.