### PR TITLE
Recalculate SVG viewbox after combining

### DIFF
--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -81,7 +81,6 @@ class Renderer(object):
                     raise
 
             processor = SvgProcessor(output_file)
-            processor.fix_dimens()
             if style == 'cut':
                 processor.apply_laser_cut_style()
             elif style == 'etch':

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -106,7 +106,6 @@ class Renderer(object):
                         svg_output = svg_processor
                     else:
                         svg_output.import_paths(svg_processor)
-        svg_output.fix_dimensions()
         output_file_path = os.path.join(self.output_folder, 'combined.svg')
         svg_output.write(output_file_path)
         return output_file_path

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -106,6 +106,7 @@ class Renderer(object):
                         svg_output = svg_processor
                     else:
                         svg_output.import_paths(svg_processor)
+        svg_output.fix_dimensions()
         output_file_path = os.path.join(self.output_folder, 'combined.svg')
         svg_output.write(output_file_path)
         return output_file_path

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -62,7 +62,7 @@ class SvgProcessor(object):
         self.svg_node.attributes['height'].value = height
 
     def set_viewbox(self, min_x, min_y, width, height):
-        view_str = "{:.1f}, {:.1f}, {:.1f}, {:.1f}".format(min_x, min_y, width, height)
+        view_str = "{:.0f}, {:.0f}, {:.0f}, {:.0f}".format(min_x, min_y, width, height)
         self.svg_node.attributes['viewBox'].value = view_str
 
     def get_viewbox(self):
@@ -103,7 +103,7 @@ class SvgProcessor(object):
 
         vb = self.merge_viewbox(from_svg_processor.get_viewbox())
         self.set_viewbox(*vb)
-        dimm = "{:.1f}mm"
+        dimm = "{:.0f}mm"
         self.set_dimensions(dimm.format(vb[2]), dimm.format(vb[3]))
 
 

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -56,11 +56,6 @@ class SvgProcessor(object):
         self.dom = minidom.parse(input_file)
         self.svg_node = self.dom.documentElement
 
-    def fix_dimens(self):
-        # Add mm units to the document dimensions
-        self.svg_node.attributes['width'].value += 'mm'
-        self.svg_node.attributes['height'].value += 'mm'
-
     def apply_laser_cut_style(self):
         # Set fill and stroke for laser cutting
         for path in self.svg_node.getElementsByTagName('path'):

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -14,7 +14,6 @@
 
 from __future__ import print_function
 from collections import defaultdict
-from math import ceil
 
 from svg.path import (
     Path,

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -61,7 +61,7 @@ class SvgProcessor(object):
         self.svg_node.attributes['height'].value = height
 
     def set_viewbox(self, min_x, min_y, width, height):
-        view_str = "{:.0f}, {:.0f}, {:.0f}, {:.0f}".format(min_x, min_y, width, height)
+        view_str = "{:.0f} {:.0f} {:.0f} {:.0f}".format(min_x, min_y, width, height)
         self.svg_node.attributes['viewBox'].value = view_str
 
     def get_viewbox(self):


### PR DESCRIPTION
Currently the combined SVG output from `generate_2d.py` uses the dimensions and [viewbox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) from the first merged file. This causes the combined SVG to render incorrectly in browsers and most viewing software, as the content extends outside of the viewing bounds. To fix it, this PR adds a few functions to the Python scripts which recalculate and set the new dimension and viewboxes for the combined SVG based off of the imported files.

Before:
![splitflap-svg-vb-before](https://user-images.githubusercontent.com/24282108/92980648-08848c00-f465-11ea-90e7-07a07916c6d3.png)

After:
![splitflap-svg-vb-after](https://user-images.githubusercontent.com/24282108/92980651-0c181300-f465-11ea-855d-f5d73f728c41.png)

(screen captures from Inkscape 1.0.1, 3bc2e813f5, 2020-09-07 - Using `View->Zoom->Drawing`)

As files are added to the combined SVG (`import_paths()`), the imported viewbox is compared against the current one. If the imported viewbox is larger in any dimension, the current viewbox is expanded to include it. The output is then saved to the SVG attributes (viewbox and dimensions).

Originally I started down this road when I noticed that the SVG dimensions were wrong on Windows. This was caused by the `fix_dimens` function, which added 'mm' to the combined output. It looks as though OpenSCAD started adding 'mm' to the SVG dimension output a few years ago, after the 'fix' function was written. On Windows the combined SVG had dimensions in "mmmm" which caused all sorts of weird sizing issues. This fixes that bug by proxy, since the width and height dimensions (including the 'mm' annotation) are replaced wholesale based off of the viewbox.

To demonstrate the updating viewbox here's a gif showing each stage in the combining process. Each SVG was exported during the `render_svgs` loop in `projection_renderer.py`, opened in Chrome, then screenshotted and combined into a gif in Photoshop:

![splitflap-svg-vb-demo](https://user-images.githubusercontent.com/24282108/92980849-82b51080-f465-11ea-976f-64f02c5c64b7.gif)

As this change doesn't touch the paths themselves it shouldn't have any effect on the final parts. It just makes the combined SVG easier to view and work with.