### PR TITLE
Round corners of sensor PCB cutouts

### DIFF
--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -115,11 +115,22 @@ module pcb() {
 // 2D cutouts needed to mount the PCB module, origin at the center of the mounting hole
 module pcb_cutouts() {
     hull_slide() {
-        translate([-m4_hole_diameter/2, -m4_hole_diameter/2]) {
-            square([m4_hole_diameter/2 + pcb_hole_to_sensor_pin_1_x + sensor_pin_pitch, m4_hole_diameter]);
+        // Bolt slot
+        hull() {
+            circle(r=m4_hole_diameter/2, $fn=30);
+            translate([pcb_hole_to_sensor_pin_1_x + sensor_pin_pitch - m4_hole_diameter/2, 0, 0])
+                circle(r=m4_hole_diameter/2, $fn=30);
         }
+        // Pin header slot
         translate([pcb_hole_to_connector_pin_1_x - connector_pin_pitch, -pcb_hole_to_connector_pin_1_x]) {
-            square([connector_pin_pitch * 4, pcb_connector_pin_width + pcb_connector_pin_slop], center=true);
+            hull() {
+                pin_slot_height = pcb_connector_pin_width + pcb_connector_pin_slop;
+                pin_slot_width = connector_pin_pitch * 4 - pin_slot_height;
+                translate([pin_slot_width/2, 0, 0])
+                    circle(pin_slot_height/2, $fn=15);
+                translate([-pin_slot_width/2, 0, 0])
+                    circle(pin_slot_height/2, $fn=15);
+            }
         }
     }
 }


### PR DESCRIPTION
Small PR, just rounding the enclosure's PCB cutouts so they're a little nicer.

### Comparison ([before](https://user-images.githubusercontent.com/24282108/93618659-943a7300-f9a5-11ea-835c-f65af123cfc9.png) / [after](https://user-images.githubusercontent.com/24282108/93618681-9ac8ea80-f9a5-11ea-8c7c-e71186054abc.png))

![sf-pcb-round-comp](https://user-images.githubusercontent.com/24282108/93618450-4aea2380-f9a5-11ea-95a4-b93b3c9d7026.gif)

### Overlaid

![sf-pcb-round-overlay](https://user-images.githubusercontent.com/24282108/93618608-7f5ddf80-f9a5-11ea-838b-88a6da5c1978.png)

