### PR TITLE
Motor flip

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -316,7 +316,7 @@ module flap_spool_complete(captive_nut=false, motor_shaft=false, magnet_hole=fal
             }
             if (magnet_hole) {
                 // Hole for press fit magnet
-                translate([magnet_hole_offset, 0]) {
+                translate([-magnet_hole_offset, 0]) {
                     circle(r=magnet_hole_radius, $fn=15);
                 }
             }
@@ -521,9 +521,9 @@ module enclosure_left() {
 
 
             // PCB mounting holes
-            translate([enclosure_height_lower - magnet_hole_offset - pcb_hole_to_sensor_y, enclosure_length - front_forward_offset - pcb_hole_to_sensor_x]) {
+            translate([enclosure_height_lower + magnet_hole_offset + pcb_hole_to_sensor_y, enclosure_length - front_forward_offset + pcb_hole_to_sensor_x]) {
                 rotate([180, 0, 0]) {
-                    rotate([0, 0, -90]) {
+                    rotate([0, 0, 90]) {
                         pcb_cutouts();
                     }
                 }
@@ -856,9 +856,9 @@ module split_flap_3d(letter, include_connector) {
 
     positioned_enclosure();
     if (render_pcb) {
-        translate([enclosure_wall_to_wall_width + eps, -pcb_hole_to_sensor_x, -magnet_hole_offset - pcb_hole_to_sensor_y]) {
+        translate([enclosure_wall_to_wall_width + eps, pcb_hole_to_sensor_x, magnet_hole_offset + pcb_hole_to_sensor_y]) {
             rotate([0, 90, 0]) {
-                rotate([0, 0, 90]) {
+                rotate([0, 0, -90]) {
                     pcb();
                     translate([0, 0, -thickness - 2 * eps]) {
                         standard_m4_bolt(nut_distance=thickness + pcb_thickness + 4*eps);

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -494,7 +494,7 @@ module enclosure_left() {
                 circle(r=m4_hole_diameter/2, $fn=30);
 
             translate([enclosure_height_lower, enclosure_length - front_forward_offset]) {
-                rotate([0, 0, 90]) {
+                rotate([0, 0, -90]) {
                     motor_mount();
                 }
             }
@@ -987,7 +987,7 @@ module split_flap_3d(letter, include_connector) {
     if (render_motor) {
         translate([enclosure_wall_to_wall_width - thickness - 28byj48_mount_bracket_height, 0, 0]) {
 
-            rotate([-90, 0, 0]) {
+            rotate([90, 0, 0]) {
 
                 rotate([0, -90, 0]) {
                     Stepper28BYJ48();


### PR DESCRIPTION
This PR flips the motor upside-down while maintaining the same shaft axis. This has two benefits: it directs the motor wires downwards for easier cable management, and it slightly reduces the assembly's center of gravity.

To accommodate the motor's new position I also moved the sensor PCB and spool magnet to align with the top of the spool, with the PCB's connector facing upwards.

### Comparison ([before](https://user-images.githubusercontent.com/24282108/93691670-7f99d000-fab6-11ea-9d64-a391527e8861.png) / [after](https://user-images.githubusercontent.com/24282108/93691675-92140980-fab6-11ea-94ba-99c0b7047b02.png)):

![sf-motor-flip-comp](https://user-images.githubusercontent.com/24282108/93691666-79a3ef00-fab6-11ea-93e9-dc70cdd6eeb5.gif)

---

I'm not entirely sold on this change, mostly because of how it affects the sensor PCB. Although it's nice to have the motor wires exit downwards, it moves the sensor PCB and its connector higher than the motor wires were originally, which somewhat defeats the point...

For a stopgap the right-angle pins could be replaced by the column from a multi-row right angle pin header ([e.g.](https://www.digikey.com/product-detail/en/samtec-inc/TSW-104-08-T-T-RA/SAM13035-ND/6691863)), although chopping up a part rather than using something off the shelf is less than ideal. Another option would be to solder the wires directly to the board instead of using a connector, which aids in the wire management but makes the build less modular.

Otherwise the PCB would need to modified to reorient the connector, probably by making the whole thing longer and narrower and having the connector exit out the back.