### PR TITLE
Mirror enclosure sides for lasercutting

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1022,17 +1022,16 @@ if (render_3d) {
     panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
     projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
         // Main enclosure (left, right, front)
-        mirror([1, 0, 0]) {
+        mirror([1, 0, 0])
             translate([-enclosure_height, 0])
                 enclosure_left();
-
+        mirror([1, 0, 0])
             translate([-enclosure_height, enclosure_length + kerf_width])
                 enclosure_right();
-
+        mirror([1, 0, 0])
             translate([-enclosure_height, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
                 rotate([0, 0, -90])
                     enclosure_front();
-        }
 
         // Top and bottom
         translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1022,16 +1022,17 @@ if (render_3d) {
     panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
     projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
         // Main enclosure (left, right, front)
-        mirror([1, 0, 0])
+        mirror([1, 0, 0]) {
             translate([-enclosure_height, 0])
                 enclosure_left();
-        mirror([1, 0, 0])
+
             translate([-enclosure_height, enclosure_length + kerf_width])
                 enclosure_right();
-        mirror([1, 0, 0])
+
             translate([-enclosure_height, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
                 rotate([0, 0, -90])
                     enclosure_front();
+        }
 
         // Top and bottom
         translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
@@ -1082,8 +1083,7 @@ if (render_3d) {
 
         // Spool retaining wall in motor window
         mirror([1, 0, 0])
-            translate([-enclosure_height, 0])
-                translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
-                    spool_retaining_wall(m4_bolt_hole=true);
+            translate([-enclosure_height_upper + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
+                spool_retaining_wall(m4_bolt_hole=true);
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1049,10 +1049,8 @@ if (render_3d) {
                     enclosure_bottom_etch();
 
         // Spool struts cut out of right side
-        mirror([1, 0, 0])
-            translate([-enclosure_height, 0])
-                translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
-                    spool_strut();
+        translate([enclosure_height - spool_strut_length - (thickness*2 + 5), enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
+            spool_strut();
 
         // Spool struts at the top
         spool_strut_y_offset = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width/2;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1028,9 +1028,10 @@ if (render_3d) {
         mirror([1, 0, 0])
             translate([-enclosure_height, enclosure_length + kerf_width])
                 enclosure_right();
-        translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
-            rotate([0, 0, -90])
-                enclosure_front();
+        mirror([1, 0, 0])
+            translate([-enclosure_height, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
+                rotate([0, 0, -90])
+                    enclosure_front();
 
         // Top and bottom
         translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
@@ -1075,7 +1076,7 @@ if (render_3d) {
 
         // Flap spools in flap window
         flap_spool_y_off = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - front_window_right_inset - enclosure_horizontal_inset - front_window_width/2;
-        flap_spool_x_off = spool_outer_radius + enclosure_height_lower - front_window_lower + kerf_width + 2;
+        flap_spool_x_off = spool_outer_radius + enclosure_height_upper - front_window_upper + kerf_width + 2;
         translate([flap_spool_x_off, flap_spool_y_off])
             flap_spool_complete(motor_shaft=true, magnet_hole=true);
         translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1022,8 +1022,9 @@ if (render_3d) {
     panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
     projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
         // Main enclosure (left, right, front)
-        translate([0, 0])
-            enclosure_left();
+        mirror([1, 0, 0])
+            translate([-enclosure_height, 0])
+                enclosure_left();
         translate([0, enclosure_length + kerf_width])
             enclosure_right();
         translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
@@ -1078,7 +1079,9 @@ if (render_3d) {
             flap_spool_complete(captive_nut=true);
 
         // Spool retaining wall in motor window
-        translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
-            spool_retaining_wall(m4_bolt_hole=true);
+        mirror([1, 0, 0])
+            translate([-enclosure_height, 0])
+                translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
+                    spool_retaining_wall(m4_bolt_hole=true);
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1025,8 +1025,9 @@ if (render_3d) {
         mirror([1, 0, 0])
             translate([-enclosure_height, 0])
                 enclosure_left();
-        translate([0, enclosure_length + kerf_width])
-            enclosure_right();
+        mirror([1, 0, 0])
+            translate([-enclosure_height, enclosure_length + kerf_width])
+                enclosure_right();
         translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
             rotate([0, 0, -90])
                 enclosure_front();
@@ -1047,8 +1048,10 @@ if (render_3d) {
                     enclosure_bottom_etch();
 
         // Spool struts cut out of right side
-        translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
-            spool_strut();
+        mirror([1, 0, 0])
+            translate([-enclosure_height, 0])
+                translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
+                    spool_strut();
 
         // Spool struts at the top
         spool_strut_y_offset = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width/2;


### PR DESCRIPTION
This PR mirrors the left, right, and front enclosure pieces on the lasercut layout so that all outward faces of the design are facing 'up' when cut. This is useful when cutting asymmetric materials like Ponoko's matte black acrylic. 

#### Before:
![sf-flat-pre-mirror](https://user-images.githubusercontent.com/24282108/99150222-effd4180-2660-11eb-95fd-488b17bf6fd7.png)

#### After:
![sf-flat-post-mirror](https://user-images.githubusercontent.com/24282108/99150227-f390c880-2660-11eb-937e-309f22fbee1a.png)

The only change to the design itself is that the spool strut cut out of the right enclosure, which has not been mirrored along with the right side. This keeps it at the same orientation as the spool struts at the top, although it effectively mirrors it around the part's Y axis. This shouldn't impact the design's functionality.
