### PR TITLE
Hall Effect Sensor Spacing and Jig

### DIFF
--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -16,12 +16,14 @@
 include <m4_dimensions.scad>;
 
 pcb_thickness = 1.6;
+sensor_spool_distance = 0.85;  // distance from the sensor to the face of the spool
 
 // From datasheet:
 hall_effect_height = (2.8 + 3.2) / 2;
 hall_effect_width = (3.9 + 4.3) / 2;
 hall_effect_thickness = (1.40 + 1.60) / 2;
 hall_effect_sensor_offset_y = hall_effect_height - 1.25;
+hall_effect_pin_length_max = 14.5;
 
 // From sensor.kicad_pcb:
 pcb_height = 16.256;
@@ -29,7 +31,6 @@ pcb_length = 16.256;
 pcb_hole_to_sensor_pin_1_x = 8.636;
 pcb_hole_to_sensor_pin_1_y = 1.27;
 sensor_pin_pitch = 1.27;
-sensor_pin_length = 8;
 pcb_hole_to_connector_pin_1_x = 8.636;
 pcb_hole_to_connector_pin_1_y = 8.636;
 connector_pin_pitch = 2.54;
@@ -57,7 +58,7 @@ pcb_sensor_pin_width = 0.43;
 
 
 // 3D PCB module, origin at the center of the mounting hole on the bottom surface of the PCB
-module pcb() {
+module pcb(pcb_to_spool) {
     color([0, 0.5, 0]) {
         linear_extrude(height=pcb_thickness) {
             difference() {
@@ -89,11 +90,14 @@ module pcb() {
         }
     }
 
-
-
     // Sensor pins
     color([0.5, 0.5, 0.5]) {
-        translate([pcb_hole_to_sensor_pin_1_x - pcb_sensor_pin_width/2, pcb_hole_to_sensor_pin_1_y - pcb_sensor_pin_width/2, -sensor_pin_length + pcb_thickness + 0.1]) {
+        pin_extra_length = 0.1;  // pins excess sticking out from the back of the PCB
+        sensor_z_offset = pcb_to_spool - sensor_spool_distance - hall_effect_thickness/2 - 0.1;
+        sensor_pin_length = sensor_z_offset + pcb_thickness + pin_extra_length;
+        assert(sensor_pin_length < hall_effect_pin_length_max, "Warning: design is too thick to fit sensor");
+
+        translate([pcb_hole_to_sensor_pin_1_x - pcb_sensor_pin_width/2, pcb_hole_to_sensor_pin_1_y - pcb_sensor_pin_width/2, -sensor_z_offset]) {
             cube([pcb_sensor_pin_width, pcb_sensor_pin_width, sensor_pin_length]);
             translate([-sensor_pin_pitch, 0, 0]) {
                 cube([pcb_sensor_pin_width, pcb_sensor_pin_width, sensor_pin_length]);
@@ -106,7 +110,7 @@ module pcb() {
 
     // Sensor body
     color([0, 0, 0]) {
-        translate([pcb_hole_to_sensor_pin_1_x - sensor_pin_pitch - hall_effect_width/2, pcb_hole_to_sensor_pin_1_y, -sensor_pin_length - hall_effect_thickness/2 + pcb_thickness]) {
+        translate([pcb_hole_to_sensor_pin_1_x - sensor_pin_pitch - hall_effect_width/2, pcb_hole_to_sensor_pin_1_y, -pcb_to_spool + sensor_spool_distance]) {
             cube([hall_effect_width, hall_effect_height, hall_effect_thickness]);
         }
     }

--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -44,6 +44,7 @@ pcb_hole_radius = m4_hole_diameter/2;
 pcb_jig_align_thickness = 2;
 pcb_jig_align_length = 0;  // past the PCB thickness
 pcb_jig_align_clearance = 0.25;  // on x, around the PCB
+pcb_jig_depth_clearance = 0.1;  // on y, from sensor to jig
 
 
 // Computed dimensions
@@ -123,7 +124,7 @@ module pcb(pcb_to_spool, render_jig=false) {
     // Jig
     if(render_jig) {
         color([1, 1, 0])
-        translate([-pcb_edge_to_hole_x - pcb_jig_align_thickness - pcb_jig_align_clearance, pcb_hole_to_sensor_pin_1_y + pcb_sensor_pin_width/2 + thickness, -pcb_to_sensor(pcb_to_spool)])
+        translate([-pcb_edge_to_hole_x - pcb_jig_align_thickness - pcb_jig_align_clearance, pcb_hole_to_sensor_pin_1_y + pcb_sensor_pin_width/2 + thickness, -pcb_to_sensor(pcb_to_spool) + pcb_jig_depth_clearance])
         rotate([90, 0, 0])
             sensor_jig(pcb_to_spool);
     }
@@ -166,13 +167,13 @@ module hull_slide() {
 }
 
 function pcb_to_sensor(pcb_to_spool) = pcb_to_spool - sensor_spool_distance - hall_effect_thickness;  // using sensor rear face
-function sensor_jig_height(pcb_to_spool) = pcb_to_sensor(pcb_to_spool) + pcb_jig_align_length + pcb_thickness;
+function sensor_jig_height(pcb_to_spool) = pcb_to_sensor(pcb_to_spool) - pcb_jig_depth_clearance + pcb_jig_align_length + pcb_thickness;
 function sensor_jig_width(pcb_to_spool) = pcb_length + (pcb_jig_align_thickness + pcb_jig_align_clearance) * 2;
 
 module sensor_jig(pcb_to_spool) {
     linear_extrude(thickness) {
         union() {
-            square([sensor_jig_width(pcb_to_spool), pcb_to_sensor(pcb_to_spool)]);  // main body
+            square([sensor_jig_width(pcb_to_spool), pcb_to_sensor(pcb_to_spool) - pcb_jig_depth_clearance]);  // main body
             square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, left
             translate([sensor_jig_width(pcb_to_spool) - pcb_jig_align_thickness, 0])
             square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, right

--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -40,6 +40,11 @@ pcb_edge_to_hole_y = 4.572;
 pcb_adjustment_range = 4;
 pcb_hole_radius = m4_hole_diameter/2;
 
+// Jig dimensions
+pcb_jig_align_thickness = 2;
+pcb_jig_align_length = 0;  // past the PCB thickness
+pcb_jig_align_clearance = 0.25;  // on x, around the PCB
+
 
 // Computed dimensions
 pcb_hole_to_sensor_x = pcb_hole_to_sensor_pin_1_x - sensor_pin_pitch;
@@ -58,7 +63,7 @@ pcb_sensor_pin_width = 0.43;
 
 
 // 3D PCB module, origin at the center of the mounting hole on the bottom surface of the PCB
-module pcb(pcb_to_spool) {
+module pcb(pcb_to_spool, render_jig=false) {
     color([0, 0.5, 0]) {
         linear_extrude(height=pcb_thickness) {
             difference() {
@@ -114,6 +119,14 @@ module pcb(pcb_to_spool) {
             cube([hall_effect_width, hall_effect_height, hall_effect_thickness]);
         }
     }
+
+    // Jig
+    if(render_jig) {
+        color([1, 1, 0])
+        translate([-pcb_edge_to_hole_x - pcb_jig_align_thickness - pcb_jig_align_clearance, pcb_hole_to_sensor_pin_1_y + pcb_sensor_pin_width/2 + thickness, -pcb_to_sensor(pcb_to_spool)])
+        rotate([90, 0, 0])
+            sensor_jig(pcb_to_spool);
+    }
 }
 
 // 2D cutouts needed to mount the PCB module, origin at the center of the mounting hole
@@ -152,3 +165,17 @@ module hull_slide() {
     }
 }
 
+function pcb_to_sensor(pcb_to_spool) = pcb_to_spool - sensor_spool_distance - hall_effect_thickness;  // using sensor rear face
+function sensor_jig_height(pcb_to_spool) = pcb_to_sensor(pcb_to_spool) + pcb_jig_align_length + pcb_thickness;
+function sensor_jig_width(pcb_to_spool) = pcb_length + (pcb_jig_align_thickness + pcb_jig_align_clearance) * 2;
+
+module sensor_jig(pcb_to_spool) {
+    linear_extrude(thickness) {
+        union() {
+            square([sensor_jig_width(pcb_to_spool), pcb_to_sensor(pcb_to_spool)]);  // main body
+            square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, left
+            translate([sensor_jig_width(pcb_to_spool) - pcb_jig_align_thickness, 0])
+            square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, right
+        }
+    }
+}

--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -16,7 +16,7 @@
 include <m4_dimensions.scad>;
 
 pcb_thickness = 1.6;
-sensor_spool_distance = 0.85;  // distance from the sensor to the face of the spool
+sensor_spool_distance = 0.70;  // distance from the sensor to the face of the spool
 
 // From datasheet:
 hall_effect_height = (2.8 + 3.2) / 2;

--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -41,6 +41,7 @@ pcb_adjustment_range = 4;
 pcb_hole_radius = m4_hole_diameter/2;
 
 // Jig dimensions
+pcb_jig_corner_fillet = 2;
 pcb_jig_align_thickness = 2;
 pcb_jig_align_length = 0;  // past the PCB thickness
 pcb_jig_align_clearance = 0.25;  // on x, around the PCB
@@ -171,12 +172,28 @@ function sensor_jig_height(pcb_to_spool) = pcb_to_sensor(pcb_to_spool) - pcb_jig
 function sensor_jig_width(pcb_to_spool) = pcb_length + (pcb_jig_align_thickness + pcb_jig_align_clearance) * 2;
 
 module sensor_jig(pcb_to_spool) {
+    module fillet() {
+        eps = 0.01;
+        difference() {
+            translate([-eps, -eps, 0])
+                square(pcb_jig_corner_fillet + eps);
+            translate([pcb_jig_corner_fillet, pcb_jig_corner_fillet, 0])
+                circle(r=pcb_jig_corner_fillet, $fn=20);
+        }
+    }
+
     linear_extrude(thickness) {
+        difference() {
         union() {
             square([sensor_jig_width(pcb_to_spool), pcb_to_sensor(pcb_to_spool) - pcb_jig_depth_clearance]);  // main body
             square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, left
             translate([sensor_jig_width(pcb_to_spool) - pcb_jig_align_thickness, 0])
             square([pcb_jig_align_thickness, sensor_jig_height(pcb_to_spool)]);  // alignment edge, right
+        }
+        fillet();
+        mirror([1, 0, 0])
+            translate([-sensor_jig_width(pcb_to_spool), 0, 0])
+                fillet();
         }
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -40,6 +40,7 @@ render_units = len(render_letters);
 render_unit_separation = 0;
 render_spool = true;
 render_pcb = true;
+render_sensor_jig = false;
 render_bolts = true;
 render_motor = true;
 
@@ -889,7 +890,7 @@ module split_flap_3d(letter, include_connector) {
         translate([enclosure_wall_to_wall_width + eps, -pcb_hole_to_sensor_x, -magnet_hole_offset - pcb_hole_to_sensor_y]) {
             rotate([0, 90, 0]) {
                 rotate([0, 0, 90]) {
-                    pcb(pcb_to_spool);
+                    pcb(pcb_to_spool, render_sensor_jig);
                     translate([0, 0, -thickness - 2 * eps]) {
                         standard_m4_bolt(nut_distance=thickness + pcb_thickness + 4*eps);
                     }
@@ -1083,5 +1084,10 @@ if (render_3d) {
         // Spool retaining wall in motor window
         translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
             spool_retaining_wall(m4_bolt_hole=true);
+
+        // Sensor soldering jig
+        translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius + motor_hole_slop/2 - kerf_width])
+            rotate([0, 0, 180])
+                sensor_jig(pcb_to_spool);
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -163,6 +163,9 @@ enclosure_horizontal_rear_margin = thickness; // minumum distance between the fa
 
 enclosure_length = front_forward_offset + 28byj48_mount_center_offset + m4_hole_diameter/2 + enclosure_horizontal_rear_margin;
 
+// distance from the outside spool face to the inside of the left enclosure
+pcb_to_spool = enclosure_wall_to_wall_width - front_window_width - thickness + spool_width_slop/2;
+
 
 // Enclosure tabs: front/back
 num_front_tabs = 2;
@@ -886,7 +889,7 @@ module split_flap_3d(letter, include_connector) {
         translate([enclosure_wall_to_wall_width + eps, -pcb_hole_to_sensor_x, -magnet_hole_offset - pcb_hole_to_sensor_y]) {
             rotate([0, 90, 0]) {
                 rotate([0, 0, 90]) {
-                    pcb();
+                    pcb(pcb_to_spool);
                     translate([0, 0, -thickness - 2 * eps]) {
                         standard_m4_bolt(nut_distance=thickness + pcb_thickness + 4*eps);
                     }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -213,6 +213,7 @@ echo(front_forward_offset=front_forward_offset);
 echo(flap_exclusion_radius=exclusion_radius);
 echo(flap_hole_radius=flap_hole_radius);
 echo(flap_notch=flap_notch);
+echo(pcb_to_sensor=pcb_to_sensor(pcb_to_spool));
 
 
 module standard_m4_bolt(nut_distance=-1) {


### PR DESCRIPTION
This PR dynamically adjusts the hall effect sensor's height off of the PCB in the model based on its distance from the spool. The sensor will maintain the same relative distance from the spool as the model is changed and throw an error if its distance from the PCB exceeds the max length of the sensor's leads (per the datasheet). I also created a small lasercut jig that fits between the PCB and the sensor to aid in soldering.

Using your v0.5 sensor assembly video as reference, I set the spool offset to `0.7 mm` which corresponds to a distance of `5.8 mm` from the PCB. Note that this PR has a conflict with #100 that will need to be resolved, as the new jig is cut out of the motor window area.

Here are some demonstration gifs, using a change in material thickness (3.2 -> 1.0) to show the dynamic position.

#### Before:
![sf-sensor-position-master](https://user-images.githubusercontent.com/24282108/99187339-1fc14d80-2724-11eb-8720-50b3e327dcc6.gif)

#### After:
![sf-sensor-position-pr](https://user-images.githubusercontent.com/24282108/99187341-22bc3e00-2724-11eb-89f5-55ab9b082ff0.gif)

And here's the change to the lasercut design ([before](https://user-images.githubusercontent.com/24282108/99187360-39fb2b80-2724-11eb-848e-68b93e99ae2b.png) / [after](https://user-images.githubusercontent.com/24282108/99187365-3b2c5880-2724-11eb-81a0-87e7d7033725.png)).

The spacing jig can be viewed in-place in the 3D design by changing `render_sensor_jig` to 'true'.



