### PR TITLE
Etched home flap indicator

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1092,11 +1092,10 @@ if (render_3d) {
         // Flap spool etching
         laser_etch() {
             translate([flap_spool_x_off, flap_spool_y_off, thickness])
-                rotate([0, 0, 180])
-                    flap_spool_etch();
+                rotate([180, 0, 0])
+                flap_spool_etch();
             translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off, thickness])
-                rotate([0, 0, 180])
-                    flap_spool_etch();
+                flap_spool_etch();
         }
 
         // Spool retaining wall in motor window

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1092,7 +1092,7 @@ if (render_3d) {
         // Flap spool etching
         laser_etch() {
             translate([flap_spool_x_off, flap_spool_y_off, thickness])
-                rotate([180, 0, 0])
+                mirror([0, 1, 0])
                 flap_spool_etch();
             translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off, thickness])
                 flap_spool_etch();

--- a/3d/spool.scad
+++ b/3d/spool.scad
@@ -35,7 +35,30 @@ module flap_spool(flaps, flap_hole_radius, flap_hole_separation, outset, height)
     } else {
         flap_spool_2d();
     }
+}
 
+module flap_spool_home_indicator(flaps, flap_hole_radius, flap_hole_separation, outset, height) {
+    pitch_radius = flap_spool_pitch_radius(flaps, flap_hole_radius, flap_hole_separation);
+    outer_radius = flap_spool_outer_radius(flaps, flap_hole_radius, flap_hole_separation, outset);
+
+    module flap_spool_home_indicator_2d() {
+        rotate([0, 0, 90])
+        translate([cos(0) * pitch_radius, sin(0) * pitch_radius])  // pitch_radius, 0
+        translate([-flap_hole_radius * 2, 0])
+        hull() {
+            circle(r=flap_hole_radius/2, $fn=30);
+            translate([-flap_hole_radius * 1.25, 0])
+            circle(r=flap_hole_radius/2, $fn=30);
+        }
+    }
+
+    if (height > 0) {
+        // convexity parameter fixes 'difference()' face polarity in preview mode... somehow
+        linear_extrude(height, convexity=2)
+            flap_spool_home_indicator_2d();
+    } else {
+        flap_spool_home_indicator_2d();
+    }
 }
 
 function flap_spool_pitch_radius(flaps, flap_hole_radius, separation) = 

--- a/3d/spool.scad
+++ b/3d/spool.scad
@@ -42,8 +42,10 @@ module flap_spool_home_indicator(flaps, flap_hole_radius, flap_hole_separation, 
     outer_radius = flap_spool_outer_radius(flaps, flap_hole_radius, flap_hole_separation, outset);
 
     module flap_spool_home_indicator_2d() {
-        rotate([0, 0, 90])
-        translate([cos(0) * pitch_radius, sin(0) * pitch_radius])  // pitch_radius, 0
+        angle = (360 / flaps) * round(0.25 * flaps);  // always point directly to a flap hole
+
+        translate([cos(angle) * pitch_radius, sin(angle) * pitch_radius])
+        rotate([0, 0, angle])
         translate([-flap_hole_radius * 2, 0])
         hull() {
             circle(r=flap_hole_radius/2, $fn=30);


### PR DESCRIPTION
As I was starting to put the flaps in my enclosure I thought it would be really nice if there was some sort of indicator for which hole was for the 'home' flap. So I added one:

![sf-home-etching-3d](https://user-images.githubusercontent.com/24282108/100047100-9ffc4880-2ddf-11eb-90c8-87f8c41499fc.png)

![sf-home-etching-2d](https://user-images.githubusercontent.com/24282108/100047093-9d015800-2ddf-11eb-99ee-ea92cede4cf6.png)

