### PR TITLE
Flap Case

### DIFF
--- a/3d/flap_container.scad
+++ b/3d/flap_container.scad
@@ -30,6 +30,9 @@ thumb_hole_diameter = 20.0;  // diameter for the thumb hole at the bottom of the
 pinch_cutout_width = 25.0;  // width of the 'pinch' opening for grabbing flaps
 pinch_cutout_offset = 12.5;  // offset from the bottom of the pinch hole to the bottom of the cavity
 
+band_slot_diameter = 10.0;  // diameter of the slot for the retaining band
+band_slot_depth = 2.5;  // depth of the retaining band slot, measured from the base to the peak
+
 fillet_case_corners = 3.0;  // bottom outside corner fillet
 fillet_flap_notch = 1.0;  // inside of flap notches, in cavity
 fillet_pinch_top = 5.0;  // at the top of the case, where the pinch cutout starts
@@ -155,10 +158,18 @@ module pinch_hole() {
     }
 }
 
+module band_slot() {
+    rotate([90, 0, 0])
+    translate([0, band_slot_depth - band_slot_diameter/2, -case_length/2 - eps])
+    linear_extrude(height=case_length + eps*2)
+    circle(r=band_slot_diameter/2, $fn=60);
+}
+
 
 difference() {
     case_body();
     flap_cavity();
     thumb_hole();
     pinch_hole();
+    band_slot();
 }

--- a/3d/flap_container.scad
+++ b/3d/flap_container.scad
@@ -32,6 +32,7 @@ pinch_cutout_offset = 12.5;  // offset from the bottom of the pinch hole to the 
 
 fillet_case_corners = 3.0;  // bottom outside corner fillet
 fillet_flap_notch = 1.0;  // inside of flap notches, in cavity
+fillet_pinch_top = 5.0;  // at the top of the case, where the pinch cutout starts
 
 
 // Calculated Values
@@ -139,8 +140,18 @@ module pinch_hole() {
     linear_extrude(height=case_length + eps*2)
     union() {
         translate([-pinch_cutout_width/2, 0, 0])
-        square([pinch_cutout_width, pinch_cutout_height - pinch_cutout_width/2 + eps]);
+            square([pinch_cutout_width, pinch_cutout_height - pinch_cutout_width/2 + eps]);
         circle(r=pinch_cutout_width/2, $fn=100);
+        
+        // left top fillet
+        translate([-pinch_cutout_width/2, pinch_cutout_height - pinch_cutout_width/2,0])
+            mirror([1, 1, 0])
+                fillet_tool(fillet_pinch_top);
+
+        // right top fillet
+        translate([pinch_cutout_width/2, pinch_cutout_height - pinch_cutout_width/2,0])
+            mirror([0, 1, 0])
+                fillet_tool(fillet_pinch_top);
     }
 }
 

--- a/3d/flap_container.scad
+++ b/3d/flap_container.scad
@@ -1,0 +1,89 @@
+/*
+   Copyright 2020 Scott Bezek and the splitflap contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+include <flap_dimensions.scad>
+use <splitflap.scad>
+
+num_flaps = 40;
+
+flap_thickness_allowance = 1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
+cavity_top_allowance = 2;  // extra case height above the flaps
+
+flap_clearance = 0.5;  // distance between the flap edges and the case walls
+wall_thickness = 3.5;  // thickness of the case walls around the flaps
+bottom_thickness = 5.0;  // thickness of the bottom of the case, below the flaps
+
+thumb_hole_diameter = 20.0;  // diameter for the thumb hole at the bottom of the case
+pinch_cutout_width = 25.0;  // width of the 'pinch' opening for grabbing flaps
+pinch_cutout_offset = 12.5;  // offset from the bottom of the pinch hole to the bottom of the cavity
+
+
+// Calculated Values
+eps = 0.01;  // extra distance for through geometry
+
+cavity_height = num_flaps * (flap_thickness + flap_thickness_allowance) + cavity_top_allowance;
+
+case_height = bottom_thickness + cavity_height;
+case_width = flap_width + flap_clearance * 2 + wall_thickness * 2;
+case_length = flap_height + flap_clearance * 2 + wall_thickness * 2;
+
+pinch_cutout_height = cavity_height - pinch_cutout_offset;  // total height of the cutout
+pinch_cutout_top_offset = case_height - cavity_height + pinch_cutout_offset + pinch_cutout_width/2;  // top of the case to the center of the pinch cutout circle
+
+module flap_position() {
+    translate([-flap_width/2, -(flap_height - flap_pin_width)/2, 0])
+    children();
+}
+
+module case_body() {
+    linear_extrude(height = case_height)
+    flap_position()
+    offset(delta = wall_thickness + flap_clearance)
+    flap_2d(cut_tabs = false);
+}
+
+module flap_cavity() {
+    translate([0, 0, case_height - cavity_height])
+    linear_extrude(height = cavity_height + eps)
+    flap_position()
+    offset(delta = flap_clearance)
+    flap_2d();
+}
+
+module thumb_hole() {
+    translate([0, 0, -eps])
+    linear_extrude(bottom_thickness + eps*2)
+    circle(r=thumb_hole_diameter/2, $fn=100);
+}
+
+module pinch_hole() {
+    rotate([90, 0, 0])
+    translate([0, pinch_cutout_top_offset , -case_length/2 - eps])
+    linear_extrude(height=case_length + eps*2)
+    union() {
+        translate([-pinch_cutout_width/2, 0, 0])
+        square([pinch_cutout_width, pinch_cutout_height - pinch_cutout_width/2 + eps]);
+        circle(r=pinch_cutout_width/2, $fn=100);
+    }
+}
+
+
+difference() {
+    case_body();
+    flap_cavity();
+    thumb_hole();
+    pinch_hole();
+}

--- a/3d/flap_container.scad
+++ b/3d/flap_container.scad
@@ -36,6 +36,7 @@ band_slot_depth = 2.5;  // depth of the retaining band slot, measured from the b
 fillet_case_corners = 3.0;  // bottom outside corner fillet
 fillet_flap_notch = 1.0;  // inside of flap notches, in cavity
 fillet_pinch_top = 5.0;  // at the top of the case, where the pinch cutout starts
+fillet_thumb_hole = 1.0;  // 3D fillet on the top inside of the thumb hole
 
 
 // Calculated Values
@@ -134,7 +135,16 @@ module flap_cavity() {
 module thumb_hole() {
     translate([0, 0, -eps])
     linear_extrude(bottom_thickness + eps*2)
-    circle(r=thumb_hole_diameter/2, $fn=100);
+        circle(r=thumb_hole_diameter/2, $fn=100);
+}
+
+module thumb_hole_fillet() {
+    translate([0, 0, bottom_thickness]) {
+        rotate_extrude($fn = 100)
+            translate([thumb_hole_diameter/2, 0, 0])
+                rotate([180, 0, 0])
+                fillet_tool(fillet_thumb_hole);
+    }
 }
 
 module pinch_hole() {
@@ -170,6 +180,7 @@ difference() {
     case_body();
     flap_cavity();
     thumb_hole();
+        thumb_hole_fillet();
     pinch_hole();
     band_slot();
 }

--- a/3d/flap_container.scad
+++ b/3d/flap_container.scad
@@ -18,6 +18,8 @@ include <flap_dimensions.scad>
 use <splitflap.scad>
 
 num_flaps = 40;
+containers_x = 1;
+containers_y = 1;
 
 flap_thickness_allowance = 1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
 cavity_top_allowance = 2;  // extra case height above the flaps
@@ -175,12 +177,23 @@ module band_slot() {
     circle(r=band_slot_diameter/2, $fn=60);
 }
 
+module flap_container() {
+    difference() {
+        case_body();
+        flap_cavity();
+        thumb_hole();
+            thumb_hole_fillet();
+        pinch_hole();
+        band_slot();
+    }
+}
 
-difference() {
-    case_body();
-    flap_cavity();
-    thumb_hole();
-        thumb_hole_fillet();
-    pinch_hole();
-    band_slot();
+union() {
+    for(x = [0 : containers_x - 1]) {
+        translate([x * (case_width - wall_thickness), 0])
+        for(y = [0 : containers_y - 1]) {
+            translate([0, y * (case_length - wall_thickness), 0])
+            flap_container();
+        }
+    }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -351,7 +351,7 @@ module spool_retaining_wall(m4_bolt_hole=false) {
 }
 
 
-module flap_2d() {
+module flap_2d(cut_tabs = true) {
     translate([0, -flap_pin_width/2, 0])
     difference() {
         union() {
@@ -365,10 +365,13 @@ module flap_2d() {
                     circle(r=flap_corner_radius, $fn=40);
             }
         }
-        translate([-eps, flap_pin_width])
-            square([eps + flap_notch_depth, flap_notch_height]);
-        translate([flap_width - flap_notch_depth, flap_pin_width])
-            square([eps + flap_notch_depth, flap_notch_height]);
+        // spool tabs
+        if(cut_tabs) {
+            translate([-eps, flap_pin_width])
+                square([eps + flap_notch_depth, flap_notch_height]);
+            translate([flap_width - flap_notch_depth, flap_pin_width])
+                square([eps + flap_notch_depth, flap_notch_height]);
+        }
     }
 }
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -355,7 +355,7 @@ module flap_2d() {
     translate([0, -flap_pin_width/2, 0])
     difference() {
         union() {
-            square([flap_width, flap_height - flap_corner_radius + eps]);
+            square([flap_width, flap_height - flap_corner_radius]);
 
             // rounded corners
             hull() {


### PR DESCRIPTION
While I was waiting for the enclosure to be lasercut I got a head start on applying the vinyl to the flaps, but had nowhere to put them. So I designed a 3D printed case that holds a full set of 40 flaps.

![sf-flap-case-views](https://user-images.githubusercontent.com/24282108/100529638-8ed48280-31b7-11eb-80c4-67843455db65.png)

The design includes a finger hole at the bottom for pushing flaps out, a 'pinch' cutout on the sides for grabbing flaps, and a rounded slot on the bottom for retaining a rubber band or other strap to keep the flaps in place. I've printed eight of these (from the Fusion 360 version of the design) and they work great.

The OpenSCAD version submitted is fully modular and will scale in height for different flap counts. I also added an array feature so you can create a single part with multiple rows and columns of containers, such as a 1x4 version for all of the modules on a single driver.