### PR TITLE
CAD Render Colors

### DIFF
--- a/3d/rough7380.scad
+++ b/3d/rough7380.scad
@@ -26,27 +26,26 @@ module roughM4_7380(length) {
     sphere_offset = 1.2;  // Just a guess
     sphere_radius = sqrt(sphere_offset*sphere_offset + (head_diameter/2)*(head_diameter/2));
 
-    color([0.75, 0.75, 0.8]) {
-        difference() {
-            union() {
-                translate([0, 0, -eps]) {
-                    cylinder(h=length+eps, d=thread_diameter, $fn=30);
+
+    difference() {
+        union() {
+            translate([0, 0, -eps]) {
+                cylinder(h=length+eps, d=thread_diameter, $fn=30);
+            }
+            difference() {
+                translate([0, 0, sphere_offset]) {
+                    sphere(sphere_radius, $fn=30);
                 }
-                difference() {
-                    translate([0, 0, sphere_offset]) {
-                        sphere(sphere_radius, $fn=30);
-                    }
-                    translate([0, 0, sphere_radius]) {
-                        cube([sphere_radius*2 + eps, sphere_radius*2 + eps, sphere_radius*2 + eps], center=true);
-                    }
-                    translate([0, 0, -sphere_radius - head_length]) {
-                        cube([sphere_radius*2 + eps, sphere_radius*2 + eps, sphere_radius*2 + eps], center=true);
-                    }
+                translate([0, 0, sphere_radius]) {
+                    cube([sphere_radius*2 + eps, sphere_radius*2 + eps, sphere_radius*2 + eps], center=true);
+                }
+                translate([0, 0, -sphere_radius - head_length]) {
+                    cube([sphere_radius*2 + eps, sphere_radius*2 + eps, sphere_radius*2 + eps], center=true);
                 }
             }
-            translate([0, 0, -head_length-eps]) {
-                cylinder(h=driving_depth+eps, r=driving_radius, $fn=6);
-            }
+        }
+        translate([0, 0, -head_length-eps]) {
+            cylinder(h=driving_depth+eps, r=driving_radius, $fn=6);
         }
     }
 }

--- a/3d/scripts/colored_stl_exporter.py
+++ b/3d/scripts/colored_stl_exporter.py
@@ -128,7 +128,15 @@ module color_extractor(c) {
             contents = COLOR_REGEX.sub(' color_selector(', contents)
             return contents + '''
         module color_selector(c) {{
-            if (c == {})
+            precision = 0.0000001;  // arbitrary
+            function compare_floats(x, y, i=0) = 
+                  (len(x) != len(y)) ? false  // if arrays differ in length, they can't be equal
+                : (i >= len(x)) ? true  // if we've hit the end of the arrays without issue, we're equal
+                : (x[i] - precision <= y[i]) && x[i] + precision >= y[i]
+                    ? compare_floats(x, y, i+1)
+                    : false;  // not equal, short circuit
+
+            if (c == {0} || compare_floats(c, {0}))
                 children();
         }}
                     '''.format(color)

--- a/3d/scripts/colored_stl_exporter.py
+++ b/3d/scripts/colored_stl_exporter.py
@@ -47,7 +47,8 @@ USE_INCLUDE_REGEX = re.compile(r'\b(?P<statement>use|include)\s*<\s*(?P<filename
 COLOR_REGEX = re.compile(r'\bcolor\s*\(')
 EXTRACTED_COLOR_REGEX = re.compile(r'ECHO: extracted_color = (?P<color>.*)')
 
-RGB_COLOR_REGEX = re.compile(r'\[(?P<r>.*?),(?P<g>.*?),(?P<b>.*?)\]')
+# RGB_COLOR_REGEX = re.compile(r'\[(?P<r>.*?),(?P<g>.*?),(?P<b>.*?)\]')
+RGBA_COLOR_REGEX = re.compile(r'\[(?P<r>[0-9.]*), *?(?P<g>[0-9.]*), *?(?P<b>[0-9.]*)(?:, *)?(?P<a>[0-9.]*)?\]')
 
 
 class ColoredStlExporter(object):
@@ -200,13 +201,18 @@ module color_extractor(c) {
 
     @staticmethod
     def parse_openscad_color(color):
-        match = RGB_COLOR_REGEX.search(color)
+        match = RGBA_COLOR_REGEX.search(color)
         if match:
-            return [
+            color_out = [
                 float(match.group('r')),
                 float(match.group('g')),
                 float(match.group('b')),
             ]
+            if(match.group('a')):
+               color_out.append(float(match.group('a')))
+
+            return color_out
+
         if '"' in color and webcolors:
             try:
                 c = webcolors.name_to_rgb(color[1:-1]) # skip the ""

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -88,12 +88,15 @@ etch_color = [0, 0, 0];  // black, "000000"
 hardware_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
 
 flap_color = [1, 1, 1];  // white, "ffffff"
-letter_color = [0, 0, 0];  // black, "000000"
 
 
 // multiply two equal matricies by each element, limiting to a max of 1.0
 function color_multiply(x, y) = 
   [ for(j=[0:len(x) - 1]) min(x[j] * y[j], 1.0) ];
+
+// inverts a color matrix by subtracting the input channel values from 1.0
+function color_invert(x) = 
+  [ for(j=[0:len(x) - 1]) (1 - x[j]) ];
 
 assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157, 1.0]);  // "e1b17c" with MDF
 assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895, 1.0]);  // "ae8960" with MDF
@@ -102,6 +105,8 @@ assembly_color4 = color_multiply(assembly_color, [0.268, 0.268, 0.271, 1.0]);  /
 
 bolt_color = hardware_color;
 nut_color = color_multiply(hardware_color, [0.933, 0.933, 0.9, 1.0]);  // "b2b2b7" with steel
+
+letter_color = color_invert(flap_color);  // inverse of the flap color, for contrast
 
 
 flap_rendered_angle = 90;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -87,6 +87,9 @@ etch_color = [0, 0, 0];  // black, "000000"
 
 hardware_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
 
+flap_color = [1, 1, 1];  // white, "ffffff"
+letter_color = [0, 0, 0];  // black, "000000"
+
 
 // multiply two equal matricies by each element, limiting to a max of 1.0
 function color_multiply(x, y) = 
@@ -388,7 +391,7 @@ module flap_2d() {
 }
 
 module flap() {
-    color([1, 1, 1])
+    color(flap_color)
     translate([0, 0, -flap_thickness/2])
     linear_extrude(height=flap_thickness) {
         flap_2d();
@@ -403,7 +406,7 @@ module draw_letter(letter) {
 }
 
 module flap_letter(letter, half = 0) {
-    color([0, 0, 0])
+    color(letter_color)
     translate([0, 0, flap_thickness/2 + eps])
     linear_extrude(height=0.1, center=true) {
         if (half != 0) {  // trimming to top (1) or bottom (2)

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -84,8 +84,7 @@ assembly_inner_radius = m4_hole_diameter/2;
 
 assembly_color = [.76, .60, .42];  // MDF, "c1996b"
 
-bolt_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
-nut_color = [0.70, 0.70, 0.72];  // steel, "b2b2b7"
+hardware_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
 
 
 // multiply two equal matricies by each element, limiting to a max of 1.0
@@ -96,6 +95,9 @@ assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157, 1.0]);  /
 assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895, 1.0]);  // "ae8960" with MDF
 assembly_color3 = color_multiply(assembly_color, [0.547, 0.542, 0.540, 1.0]);  // "6a533a" with MDF
 assembly_color4 = color_multiply(assembly_color, [0.268, 0.268, 0.271, 1.0]);  // "34291d" with MDF
+
+bolt_color = hardware_color;
+nut_color = color_multiply(hardware_color, [0.933, 0.933, 0.9, 1.0]);  // "b2b2b7" with steel
 
 
 flap_rendered_angle = 90;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -84,6 +84,9 @@ assembly_inner_radius = m4_hole_diameter/2;
 
 assembly_color = [.76, .60, .42];  // MDF, "c1996b"
 
+bolt_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
+nut_color = [0.70, 0.70, 0.72];  // steel, "b2b2b7"
+
 
 // multiply two equal matricies by each element, limiting to a max of 1.0
 function color_multiply(x, y) = 
@@ -228,9 +231,10 @@ echo(flap_notch_height=flap_notch_height);
 
 module standard_m4_bolt(nut_distance=-1) {
     if (render_bolts) {
-        roughM4_7380(10);
+        color(bolt_color)
+            roughM4_7380(10);
         if (nut_distance >= 0) {
-            color([0.70, 0.70, 0.72]) {
+            color(nut_color) {
                 translate([0, 0, nut_distance]) {
                     linear_extrude(m4_nut_length) {
                         difference() {

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -81,11 +81,19 @@ captive_nut_inset=6;
 
 assembly_inner_radius = m4_hole_diameter/2;
 
-assembly_color = [.76, .60, .42];
-assembly_color1 = [.882, .694, .486]; //"e1b17c";
-assembly_color2 = [.682, .537, .376]; //"ae8960";
-assembly_color3 = [.416, .325, .227]; //"6A533A";
-assembly_color4 = [.204, .161, .114]; //"34291D";
+
+assembly_color = [.76, .60, .42];  // MDF, "c1996b"
+
+
+// multiply two equal matricies by each element, limiting to a max of 1.0
+function color_multiply(x, y) = 
+  [ for(j=[0:len(x) - 1]) min(x[j] * y[j], 1.0) ];
+
+assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157]);  // "e1b17c" with MDF
+assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895]);  // "ae8960" with MDF
+assembly_color3 = color_multiply(assembly_color, [0.547, 0.542, 0.540]);  // "6a533a" with MDF
+assembly_color4 = color_multiply(assembly_color, [0.268, 0.268, 0.271]);  // "34291d" with MDF
+
 
 flap_rendered_angle = 90;
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -83,6 +83,7 @@ assembly_inner_radius = m4_hole_diameter/2;
 
 
 assembly_color = [.76, .60, .42];  // MDF, "c1996b"
+etch_color = [0, 0, 0];  // black, "000000"
 
 hardware_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
 
@@ -348,7 +349,7 @@ module flap_spool_complete(captive_nut=false, motor_shaft=false, magnet_hole=fal
 }
 
 module flap_spool_etch() {
-    color([0, 0, 0])
+    color(etch_color)
     flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset, spool_etch_depth);
 }
 
@@ -757,7 +758,7 @@ module enclosure_bottom() {
 }
 
 module enclosure_bottom_etch() {
-    color([0, 0, 0])
+    color(etch_color)
     linear_extrude(height=2, center=true) {
         translate([captive_nut_inset + m4_nut_length + 1, 1, thickness]) {
             text_label([str("rev. ", render_revision), render_date, "github.com/scottbez1/splitflap"]);

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -89,10 +89,10 @@ assembly_color = [.76, .60, .42];  // MDF, "c1996b"
 function color_multiply(x, y) = 
   [ for(j=[0:len(x) - 1]) min(x[j] * y[j], 1.0) ];
 
-assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157]);  // "e1b17c" with MDF
-assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895]);  // "ae8960" with MDF
-assembly_color3 = color_multiply(assembly_color, [0.547, 0.542, 0.540]);  // "6a533a" with MDF
-assembly_color4 = color_multiply(assembly_color, [0.268, 0.268, 0.271]);  // "34291d" with MDF
+assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157, 1.0]);  // "e1b17c" with MDF
+assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895, 1.0]);  // "ae8960" with MDF
+assembly_color3 = color_multiply(assembly_color, [0.547, 0.542, 0.540, 1.0]);  // "6a533a" with MDF
+assembly_color4 = color_multiply(assembly_color, [0.268, 0.268, 0.271, 1.0]);  // "34291d" with MDF
 
 
 flap_rendered_angle = 90;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -82,7 +82,8 @@ captive_nut_inset=6;
 assembly_inner_radius = m4_hole_diameter/2;
 
 
-assembly_color = [.76, .60, .42];  // MDF, "c1996b"
+// Rendering Colors
+assembly_color = [0.76, 0.60, 0.42];  // MDF, "c1996b"
 etch_color = [0, 0, 0];  // black, "000000"
 
 hardware_color = [0.75, 0.75, 0.8];  // steel, "bfbfcc"
@@ -91,12 +92,12 @@ flap_color = [1, 1, 1];  // white, "ffffff"
 
 
 // multiply two equal matricies by each element, limiting to a max of 1.0
-function color_multiply(x, y) = 
-  [ for(j=[0:len(x) - 1]) min(x[j] * y[j], 1.0) ];
+function color_multiply(x, y) =
+    [ for(j=[0:len(x) - 1]) min(x[j] * y[j], 1.0) ];
 
 // inverts a color matrix by subtracting the input channel values from 1.0
-function color_invert(x) = 
-  [ for(j=[0:len(x) - 1]) (1 - x[j]) ];
+function color_invert(x) =
+    [ for(j=[0:len(x) - 1]) (1.0 - x[j]) ];
 
 assembly_color1 = color_multiply(assembly_color, [1.161, 1.157, 1.157, 1.0]);  // "e1b17c" with MDF
 assembly_color2 = color_multiply(assembly_color, [0.897, 0.895, 0.895, 1.0]);  // "ae8960" with MDF


### PR DESCRIPTION
I've made a number of changes to the assembly to make it easy to adjust the colors.

First, the assembly color variations are now generated from a single base color. This means you can change the one 'assembly' color and still keep the color variation between parts. The scalars were calculated from the current values so everything should keep the same appearance as before. The etch color, similarly, has been broken out into a variable and can now be changed.

Second, I've added variables for the hardware (nuts + bolts) and flap color. This allows you to change out the steel hardware for black oxide or swap the flaps from white to black. The letter color is calculated as the inverse of the flap color, so white flaps get black letters and black flaps get white letters (and red flaps get cyan letters and so on and so forth).

There should be no functional changes to the design.

#### Default: MDF, white flaps, steel hardware

![sf-colors-default](https://user-images.githubusercontent.com/24282108/101127346-5f64b200-35cb-11eb-91b1-963ef6be58fc.png)

#### Demo: Matte black acrylic, black flaps, black oxide hardware

![sf-colors-matte-black](https://user-images.githubusercontent.com/24282108/101127339-5d9aee80-35cb-11eb-83da-f913f9de5535.png)

Using:
```cpp
assembly_color = [0.1, 0.1, 0.1];
etch_color = [0.5, 0.5, 0.5];
hardware_color = [0.2, 0.2, 0.2];
flap_color = [0, 0, 0];
```