### PR TITLE
Laser Layout Mirror Option

### DIFF
--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -44,6 +44,8 @@ if __name__ == '__main__':
     parser.add_argument('--render-raster', action='store_true', help='Render raster PNG from the output SVG (requires '
                                                                      'Inkscape)')
     parser.add_argument('--thickness', type=float, help='Override panel thickness value')
+    parser.add_argument('--mirror', action='store_true', help='Mirror the assembly so the outside faces are facing up. '
+                                                              'Note that this will put the etchings on the outside.')
 
     args = parser.parse_args()
 
@@ -52,6 +54,7 @@ if __name__ == '__main__':
     extra_variables = {
         'render_revision': rev_info.git_short_rev(),
         'render_date': rev_info.current_date(),
+        'render_2d_mirror' : args.mirror,
     }
     if args.kerf is not None:
         extra_variables['kerf_width'] = args.kerf

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -44,8 +44,9 @@ if __name__ == '__main__':
     parser.add_argument('--render-raster', action='store_true', help='Render raster PNG from the output SVG (requires '
                                                                      'Inkscape)')
     parser.add_argument('--thickness', type=float, help='Override panel thickness value')
+    parser.add_argument('--no-etch', action='store_true', help='Do not render laser-etched features')
     parser.add_argument('--mirror', action='store_true', help='Mirror the assembly so the outside faces are facing up. '
-                                                              'Note that this will put the etchings on the outside.')
+                                                              'Note that this will remove all etched features.')
 
     args = parser.parse_args()
 
@@ -54,6 +55,7 @@ if __name__ == '__main__':
     extra_variables = {
         'render_revision': rev_info.git_short_rev(),
         'render_date': rev_info.current_date(),
+        'render_etch' : not args.no_etch,
         'render_2d_mirror' : args.mirror,
     }
     if args.kerf is not None:

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -61,7 +61,10 @@ class Renderer(object):
 
     def _render_component(self, i, panel_horizontal, panel_vertical):
         output_file = self._get_component_file(i)
-        for style in ('cut', 'etch'):
+        style_options = ['cut']
+        if self.etch_enabled:
+            style_options.append('etch')
+        for style in (style_options):
             logging.debug('Rendering component %d, %s', i, style)
             try:
                 _ = openscad.run(
@@ -70,7 +73,7 @@ class Renderer(object):
                         variables=self._get_variables({
                             'render_3d': False,
                             'render_index': i,
-                            'render_etch': style == 'etch' and self.etch_enabled,
+                            'render_etch': style == 'etch',
                             'panel_horizontal': panel_horizontal,
                             'panel_vertical': panel_vertical,
                         }),
@@ -80,8 +83,6 @@ class Renderer(object):
                 if b'Current top level object is not a 2D object.' in e.stderr:
                     # This is expected if we try rendering an etch layer as a
                     # cut, since there will be nothing to export
-                    if not self.etch_enabled:
-                        break  # no reason to continue looping if no etched geometry
                     continue
                 else:
                     raise

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -87,7 +87,10 @@ class Renderer(object):
                 processor.apply_laser_etch_style()
             break
         else:
-            raise ValueError("Invalid component!", i)
+            # if a part is neither cut nor etched, there is no data to export
+            logging.debug('Component %d has no geometry', i)
+            return None
+
         return processor
 
     def render_svgs(self, panelize_quantity):
@@ -104,7 +107,7 @@ class Renderer(object):
                     svg_processor = self._render_component(i, panel_horizontal, panel_vertical)
                     if svg_output is None:
                         svg_output = svg_processor
-                    else:
+                    elif svg_processor is not None:
                         svg_output.import_paths(svg_processor)
         output_file_path = os.path.join(self.output_folder, 'combined.svg')
         svg_output.write(output_file_path)

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -80,6 +80,8 @@ class Renderer(object):
                 if b'Current top level object is not a 2D object.' in e.stderr:
                     # This is expected if we try rendering an etch layer as a
                     # cut, since there will be nothing to export
+                    if not self.etch_enabled:
+                        break  # no reason to continue looping if no etched geometry
                     continue
                 else:
                     raise
@@ -89,13 +91,10 @@ class Renderer(object):
                 processor.apply_laser_cut_style()
             elif style == 'etch':
                 processor.apply_laser_etch_style()
-            break
-        else:
-            # if a part is neither cut nor etched, there is no data to export
-            logging.debug('Component %d has no geometry', i)
-            return None
+            return processor
 
-        return processor
+        logging.debug('Component %d has no geometry', i)
+        return None
 
     def render_svgs(self, panelize_quantity):
         assert panelize_quantity == 1 or panelize_quantity % 2 == 0, 'Panelize quantity must be 1 or an even number'

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -29,6 +29,10 @@ class Renderer(object):
         if extra_variables is None:
             extra_variables = {}
         self.extra_variables = extra_variables
+        try:
+            self.etch_enabled = self.extra_variables['render_etch']
+        except KeyError:
+            self.etch_enabled = True
 
     def clean(self):
         shutil.rmtree(self.output_folder, ignore_errors=True)
@@ -66,7 +70,7 @@ class Renderer(object):
                         variables=self._get_variables({
                             'render_3d': False,
                             'render_index': i,
-                            'render_etch': style == 'etch',
+                            'render_etch': style == 'etch' and self.etch_enabled,
                             'panel_horizontal': panel_horizontal,
                             'panel_vertical': panel_vertical,
                         }),

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -47,6 +47,7 @@ render_motor = true;
 // 2d parameters:
 render_index = -1;
 render_etch = false;
+render_2d_mirror = false;
 
 // Panelization:
 panel_vertical = 0;
@@ -1066,6 +1067,16 @@ module laser_etch() {
     }
 }
 
+module laser_setup() {
+    if (render_2d_mirror) {
+        mirror([1, 0, 0])
+            children();
+    }
+    else {
+        children();
+    }
+}
+
 if (render_3d) {
     for (i = [0 : render_units - 1]) {
         translate([-enclosure_width/2 + (-(render_units-1) / 2 + i)*(enclosure_width + render_unit_separation), 0, 0])
@@ -1075,49 +1086,66 @@ if (render_3d) {
     panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
     projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
         // Main enclosure (left, right, front)
+        laser_setup()
         translate([0, 0])
             enclosure_left();
+
+        laser_setup()
         translate([0, enclosure_length + kerf_width])
             enclosure_right();
+
+        laser_setup()
         translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
             rotate([0, 0, -90])
                 enclosure_front();
 
         // Top and bottom
+        laser_setup()
         translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
             rotate([0, 0, 90])
                 enclosure_top();
 
+        laser_setup()
         translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width])
             rotate([0, 0, -90])
                 enclosure_bottom();
 
         // Bottom laser etching
+        laser_setup()
         laser_etch()
             translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width, thickness])
                 rotate([0, 0, -90])
                     enclosure_bottom_etch();
 
         // Spool struts cut out of right side
+        laser_setup()
         translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
             spool_strut();
 
         // Spool struts at the top
         spool_strut_y_offset = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width/2;
+
+        laser_setup()
         translate([spool_strut_length, spool_strut_y_offset, thickness/2])
             rotate([0, 0, 180])
                 spool_strut();
+
+        laser_setup()
         translate([spool_strut_length*2 + kerf_width, spool_strut_y_offset, thickness/2])
             rotate([0, 0, 180])
                 spool_strut();
+
+        laser_setup()
         translate([spool_strut_length*3 + kerf_width*2, spool_strut_y_offset, thickness/2])
             rotate([0, 0, 180])
                 spool_strut();
 
         // Connector brackets on the top right
+        laser_setup()
         translate([enclosure_height + kerf_width, 2 * enclosure_wall_to_wall_width + 2 * kerf_width - thickness, 0])
             connector_bracket();
 
+        laser_setup()
         translate([enclosure_height + kerf_width + connector_bracket_width - connector_bracket_length_outer, 2 * enclosure_wall_to_wall_width + 3 * kerf_width - thickness + connector_bracket_width + connector_bracket_length_outer, 0])
             rotate([0,0,-90])
                 connector_bracket();
@@ -1125,12 +1153,17 @@ if (render_3d) {
         // Flap spools in flap window
         flap_spool_y_off = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - front_window_right_inset - enclosure_horizontal_inset - front_window_width/2;
         flap_spool_x_off = spool_outer_radius + enclosure_height_lower - front_window_lower + kerf_width + 2;
+
+        laser_setup()
         translate([flap_spool_x_off, flap_spool_y_off])
             flap_spool_complete(motor_shaft=true, magnet_hole=true);
+
+        laser_setup()
         translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
             flap_spool_complete(captive_nut=true);
 
         // Flap spool etching
+        laser_setup()
         laser_etch() {
             translate([flap_spool_x_off, flap_spool_y_off, thickness])
                 mirror([0, 1, 0])
@@ -1140,10 +1173,12 @@ if (render_3d) {
         }
 
         // Spool retaining wall in motor window
+        laser_setup()
         translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
             spool_retaining_wall(m4_bolt_hole=true);
 
         // Sensor soldering jig
+        laser_setup()
         translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius + motor_hole_slop/2 - kerf_width])
             rotate([0, 0, 180])
                 sensor_jig(pcb_to_spool);

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1139,7 +1139,7 @@ module split_flap_3d(letter, include_connector) {
 }
 
 module laser_etch() {
-    if (render_etch || render_index == -1) {
+    if (!render_2d_mirror && (render_etch || render_index == -1)) {
         children();
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -775,9 +775,21 @@ module enclosure_bottom() {
     }
 }
 
-module enclosure_bottom_etch() {
+module enclosure_bottom_etch_mirror(mirror_text) {
+    if(mirror_text) {
+        mirror([1, 0, 0])
+            translate([-enclosure_wall_to_wall_width, 0, 0])
+                children();
+    }
+    else {
+        children();
+    }
+}
+
+module enclosure_bottom_etch(mirror_text=false) {
     color(etch_color)
     linear_extrude(height=2, center=true) {
+        enclosure_bottom_etch_mirror(mirror_text)
         translate([captive_nut_inset + m4_nut_length + 1, 1, thickness]) {
             text_label([str("rev. ", render_revision), render_date, "github.com/scottbez1/splitflap"]);
         }
@@ -1115,7 +1127,7 @@ if (render_3d) {
         laser_etch()
             translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width, thickness])
                 rotate([0, 0, -90])
-                    enclosure_bottom_etch();
+                    enclosure_bottom_etch(render_2d_mirror);
 
         // Spool struts cut out of right side
         laser_setup()

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1079,7 +1079,7 @@ module laser_etch() {
     }
 }
 
-module laser_setup() {
+module laser_mirror() {
     if (render_2d_mirror) {
         mirror([1, 0, 0])
             children();
@@ -1095,104 +1095,89 @@ if (render_3d) {
             split_flap_3d(render_letters[render_units - 1 - i], include_connector=(i != render_units - 1));
     }
 } else {
-    panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
-    projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
-        // Main enclosure (left, right, front)
-        laser_setup()
-        translate([0, 0])
-            enclosure_left();
+    laser_mirror() {
+        panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;
+        projection_renderer(render_index=render_index, render_etch=render_etch, kerf_width=kerf_width, panel_height=panel_height, panel_horizontal=panel_horizontal, panel_vertical=panel_vertical) {
+            // Main enclosure (left, right, front)
+            translate([0, 0])
+                enclosure_left();
 
-        laser_setup()
-        translate([0, enclosure_length + kerf_width])
-            enclosure_right();
+            translate([0, enclosure_length + kerf_width])
+                enclosure_right();
 
-        laser_setup()
-        translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
-            rotate([0, 0, -90])
-                enclosure_front();
-
-        // Top and bottom
-        laser_setup()
-        translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
-            rotate([0, 0, 90])
-                enclosure_top();
-
-        laser_setup()
-        translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width])
-            rotate([0, 0, -90])
-                enclosure_bottom();
-
-        // Bottom laser etching
-        laser_setup()
-        laser_etch()
-            translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width, thickness])
+            translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
                 rotate([0, 0, -90])
-                    enclosure_bottom_etch(render_2d_mirror);
+                    enclosure_front();
 
-        // Spool struts cut out of right side
-        laser_setup()
-        translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
-            spool_strut();
+            // Top and bottom
+            translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
+                rotate([0, 0, 90])
+                    enclosure_top();
 
-        // Spool struts at the top
-        spool_strut_y_offset = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width/2;
+            translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width])
+                rotate([0, 0, -90])
+                    enclosure_bottom();
 
-        laser_setup()
-        translate([spool_strut_length, spool_strut_y_offset, thickness/2])
-            rotate([0, 0, 180])
+            // Bottom laser etching
+            laser_etch()
+                translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width, thickness])
+                    rotate([0, 0, -90])
+                        enclosure_bottom_etch(render_2d_mirror);
+
+            // Spool struts cut out of right side
+            translate([thickness*2 + 5, enclosure_length + kerf_width + enclosure_length_right - spool_strut_width/2 - 3, thickness])
                 spool_strut();
 
-        laser_setup()
-        translate([spool_strut_length*2 + kerf_width, spool_strut_y_offset, thickness/2])
-            rotate([0, 0, 180])
-                spool_strut();
+            // Spool struts at the top
+            spool_strut_y_offset = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width/2;
 
-        laser_setup()
-        translate([spool_strut_length*3 + kerf_width*2, spool_strut_y_offset, thickness/2])
-            rotate([0, 0, 180])
-                spool_strut();
+            translate([spool_strut_length, spool_strut_y_offset, thickness/2])
+                rotate([0, 0, 180])
+                    spool_strut();
 
-        // Connector brackets on the top right
-        laser_setup()
-        translate([enclosure_height + kerf_width, 2 * enclosure_wall_to_wall_width + 2 * kerf_width - thickness, 0])
-            connector_bracket();
+            translate([spool_strut_length*2 + kerf_width, spool_strut_y_offset, thickness/2])
+                rotate([0, 0, 180])
+                    spool_strut();
 
-        laser_setup()
-        translate([enclosure_height + kerf_width + connector_bracket_width - connector_bracket_length_outer, 2 * enclosure_wall_to_wall_width + 3 * kerf_width - thickness + connector_bracket_width + connector_bracket_length_outer, 0])
-            rotate([0,0,-90])
+            translate([spool_strut_length*3 + kerf_width*2, spool_strut_y_offset, thickness/2])
+                rotate([0, 0, 180])
+                    spool_strut();
+
+            // Connector brackets on the top right
+            translate([enclosure_height + kerf_width, 2 * enclosure_wall_to_wall_width + 2 * kerf_width - thickness, 0])
                 connector_bracket();
 
-        // Flap spools in flap window
-        flap_spool_y_off = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - front_window_right_inset - enclosure_horizontal_inset - front_window_width/2;
-        flap_spool_x_off = spool_outer_radius + enclosure_height_lower - front_window_lower + kerf_width + 2;
+            translate([enclosure_height + kerf_width + connector_bracket_width - connector_bracket_length_outer, 2 * enclosure_wall_to_wall_width + 3 * kerf_width - thickness + connector_bracket_width + connector_bracket_length_outer, 0])
+                rotate([0,0,-90])
+                    connector_bracket();
 
-        laser_setup()
-        translate([flap_spool_x_off, flap_spool_y_off])
-            flap_spool_complete(motor_shaft=true, magnet_hole=true);
+            // Flap spools in flap window
+            flap_spool_y_off = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - front_window_right_inset - enclosure_horizontal_inset - front_window_width/2;
+            flap_spool_x_off = spool_outer_radius + enclosure_height_lower - front_window_lower + kerf_width + 2;
 
-        laser_setup()
-        translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
-            flap_spool_complete(captive_nut=true);
+            translate([flap_spool_x_off, flap_spool_y_off])
+                flap_spool_complete(motor_shaft=true, magnet_hole=true);
 
-        // Flap spool etching
-        laser_setup()
-        laser_etch() {
-            translate([flap_spool_x_off, flap_spool_y_off, thickness])
-                mirror([0, 1, 0])
-                flap_spool_etch();
-            translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off, thickness])
-                flap_spool_etch();
+            translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
+                flap_spool_complete(captive_nut=true);
+
+            // Flap spool etching
+            laser_etch() {
+                translate([flap_spool_x_off, flap_spool_y_off, thickness])
+                    mirror([0, 1, 0])
+                    flap_spool_etch();
+                translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off, thickness])
+                    flap_spool_etch();
+            }
+
+            // Spool retaining wall in motor window
+            translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
+                spool_retaining_wall(m4_bolt_hole=true);
+
+            // Sensor soldering jig
+            translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius + motor_hole_slop/2 - kerf_width])
+                rotate([0, 0, 180])
+                    sensor_jig(pcb_to_spool);
         }
-
-        // Spool retaining wall in motor window
-        laser_setup()
-        translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
-            spool_retaining_wall(m4_bolt_hole=true);
-
-        // Sensor soldering jig
-        laser_setup()
-        translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius + motor_hole_slop/2 - kerf_width])
-            rotate([0, 0, 180])
-                sensor_jig(pcb_to_spool);
     }
 }


### PR DESCRIPTION
This adds the option to mirror the 2D laser-cut design so that the outside faces are facing 'up' / towards the laser when cut. This is useful for materials with a special finish on only one side like Ponoko's matte black acrylic, which is cut with the matte finish facing towards the laser.

The mirroring can be set with the `render_2d_mirror` flag, or with the `--mirror` option in the `generate_2d.py` script.

This continues the conversation from PR #100, and offers an alternate solution to the same issue.