### PR TITLE
Organize 3D printed tools

### DIFF
--- a/3d/tools/flap_container.scad
+++ b/3d/tools/flap_container.scad
@@ -14,8 +14,8 @@
    limitations under the License.
 */
 
-include <flap_dimensions.scad>
-use <splitflap.scad>
+include <../flap_dimensions.scad>
+use <../splitflap.scad>
 
 num_flaps = 40;
 containers_x = 1;

--- a/3d/tools/pcb_case.scad
+++ b/3d/tools/pcb_case.scad
@@ -44,6 +44,7 @@ mounting_boss_height = pcb_thickness + 0.4;  // distance above the PCB for the m
 
 // calculations
 eps = 0.01;
+pcb_to_spool = 7.8;  // dummy for PCB render, as we don't have the whole assembly for this value
 
 combined_clearance = pcb_edge_clearance + case_wall_thickness;  // total edge clearance, from PCB edge to outside edge
 pcb_cutout_depth = pcb_thickness + pcb_connector_height/2 + pcb_depth_clearance;  // depth of the PCB cutout, from top
@@ -218,7 +219,7 @@ module pcb_case(with_pcb=false) {
 
         if(with_pcb) {
             translate([0, 0, pcb_cutout_plane])
-                pcb();
+                pcb(pcb_to_spool);
         }
     }
 }

--- a/3d/tools/pcb_case.scad
+++ b/3d/tools/pcb_case.scad
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-include<pcb.scad>;
+include<../pcb.scad>;
 
 render_pcb = false;  // draw PCB in position in case
 cases_per_row = 1;  // number of cases per each row

--- a/3d/tools/punch_jig.scad
+++ b/3d/tools/punch_jig.scad
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-include<flap_dimensions.scad>;
+include<../flap_dimensions.scad>;
 
 print_tolerance = 0.1;
 jig_thickness = 2;

--- a/3d/tools/scoring_jig.scad
+++ b/3d/tools/scoring_jig.scad
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-include<flap_dimensions.scad>
+include<../flap_dimensions.scad>
 
 print_tolerance = 0.1;
 eps = 0.1;

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ The `generate_gif.py` script runs multiple OpenSCAD instances in parallel to ren
 ##### STL models/web viewer #####
 The design can be rendered to a series of STL files (one per color used in the model) in order to be displayed in an [interactive web-based 3d viewer](https://scottbez1.github.io/splitflap/). Similar to the `projection_renderer` used to render individual components for laser-cutting, the [ColoredStlExporter](3d/scripts/colored_stl_exporter.py) detects all the colors used in the model and renders them one-by-one to separate STL files, along with a manifest that maps each STL file to its RGB color. The STL files and manifest are loaded using three.js to display an interactive model on a web site using WebGL. See this blog post for more details on how the export and three.js renderer work: [OpenSCAD Rendering Tricks, Part 3: Web viewer](http://scottbezek.blogspot.com/2016/08/openscad-rendering-tricks-part-3-web.html).
 
+#### 3D Printed Tools ####
+The project also includes a number of optional 3D printed designs to make assembly easier. These include:
+
+* [a flap scoring jig](3d/tools/scoring_jig.scad) for precisely marking the cut point when splitting CR80 cards
+* [a flap punch jig](3d/tools/punch_jig.scad) for aligning the punch when making the pin cutouts on either side of a flap
+* [a flap container](3d/tools/flap_container.scad) for storing and organizing stacks of completed flaps
+* [a sensor PCB holder](3d/tools/pcb_case.scad) for storing and protecting soldered sensor boards
+
+All of these designs are parametric and customizable within OpenSCAD. To print them, open up the relevant file in OpenSCAD and use `File -> Export -> Export as STL` to render the design as an STL file for your slicer.
 
 ### Driver Electronics ###
 The driver board is designed to plug into an Arduino like a shield, and can control 4 stepper motors.


### PR DESCRIPTION
Collects all of the 3D printed tool designs in a subfolder to try and keep the CAD files at least somewhat organized. Also fixes a bug with the optional PCB rendering in the PCB case design and adds a section to the README about these designs (per your comment in #103 :smile:).