### PR TITLE
Zip Ties for Cable Management

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -265,31 +265,6 @@ echo(flap_notch_height=flap_notch_height);
 echo(pcb_to_sensor=pcb_to_sensor(pcb_to_spool));
 
 
-module rounded_square(size, center=false, r=0.0, $fn=$fn) {
-    width  = size[0] == undef ? size : size[0];  // unpack vector if present
-    height = size[1] == undef ? size : size[1];
-
-    if(r <= 0.0) {
-        square([width, height], center=center);
-    } else {
-        radius = min(min(r, width/2), height/2);  // radius cannot be larger than rectangle
-        center_x = center ? 0 : width/2;
-        center_y = center ? 0 : height/2;
-
-        translate([center_x, center_y])
-            hull() {
-                x =  width/2 - radius;
-                y = height/2 - radius;
-
-                translate([ x,  y]) circle(r=radius, $fn=$fn);
-                translate([ x, -y]) circle(r=radius, $fn=$fn);
-                translate([-x, -y]) circle(r=radius, $fn=$fn);
-                translate([-x,  y]) circle(r=radius, $fn=$fn);
-            }
-    }
-}
-
-
 module standard_m4_bolt(nut_distance=-1) {
     if (render_bolts) {
         color(bolt_color)

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -258,7 +258,7 @@ echo(flap_notch_height=flap_notch_height);
 echo(pcb_to_sensor=pcb_to_sensor(pcb_to_spool));
 
 
-module rounded_square(size, center=false, r=0.0) {
+module rounded_square(size, center=false, r=0.0, $fn=$fn) {
     width  = size[0] == undef ? size : size[0];  // unpack vector if present
     height = size[1] == undef ? size : size[1];
 
@@ -268,17 +268,16 @@ module rounded_square(size, center=false, r=0.0) {
         radius = min(min(r, width/2), height/2);  // radius cannot be larger than hole
         center_x = center ? 0 : width/2;
         center_y = center ? 0 : height/2;
-        fn = 30;
 
         translate([center_x, center_y])
             hull() {
                 x =  width/2 - radius;
                 y = height/2 - radius;
 
-                translate([ x,  y]) circle(r=radius, $fn=fn);
-                translate([ x, -y]) circle(r=radius, $fn=fn);
-                translate([-x, -y]) circle(r=radius, $fn=fn);
-                translate([-x,  y]) circle(r=radius, $fn=fn);
+                translate([ x,  y]) circle(r=radius, $fn=$fn);
+                translate([ x, -y]) circle(r=radius, $fn=$fn);
+                translate([-x, -y]) circle(r=radius, $fn=$fn);
+                translate([-x,  y]) circle(r=radius, $fn=$fn);
             }
     }
 }
@@ -324,9 +323,9 @@ module zip_tie_holes() {
     spacing = (zip_tie_spacing + zip_tie_width)/2;
 
     translate([-spacing, 0, 0])
-        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet);
+        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet, $fn=30);
     translate([spacing, 0, 0])
-        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet);
+        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet, $fn=30);
 }
 
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -226,6 +226,11 @@ connector_bracket_depth_clearance = 0.20;
 
 mounting_hole_inset = m4_button_head_diameter/2 + 2;
 
+zip_tie_height = 3.0;  // height of the zip-tie hole
+zip_tie_width = 2.0;  // width of the zip-tie holes
+zip_tie_spacing = 6.5;  // spacing between each zip-tie hole, inside edges
+zip_tie_fillet = 0.5;  // radius of the rounded zip-tie hole corners
+
 echo(kerf_width=kerf_width);
 echo(enclosure_height=enclosure_height);
 echo(enclosure_height_upper=enclosure_height_upper);
@@ -306,6 +311,16 @@ module captive_nut(bolt_diameter, bolt_length, nut_width, nut_length, nut_inset)
 }
 module m4_captive_nut(bolt_length=m4_bolt_length) {
     captive_nut(m4_hole_diameter, bolt_length + 1, m4_nut_width_flats, m4_nut_length_padded, captive_nut_inset);
+}
+
+
+module zip_tie_holes() {
+    spacing = (zip_tie_spacing + zip_tie_width)/2;
+
+    translate([-spacing, 0, 0])
+        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet);
+    translate([spacing, 0, 0])
+        rounded_square([zip_tie_width, zip_tie_height], center=true, r=zip_tie_fillet);
 }
 
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -647,12 +647,12 @@ module enclosure_left() {
                 }
             }
 
-            // Zip tie holes, sensor (leading to bottom)            
+            // Zip tie holes, sensor (leading to bottom)
             translate([enclosure_left_zip_bottom_inset, zip_tie_height/2 + enclosure_left_zip_side_inset, 0])
                 zip_tie_holes();
 
             // Zip tie holes, motor (leading to top)
-            translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length/2])
+            translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length - front_forward_offset])
                 rotate([0, 0, 90])  // cable channel facing 'up'
                     zip_tie_holes();
         }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -247,6 +247,32 @@ echo(flap_notch_height=flap_notch_height);
 echo(pcb_to_sensor=pcb_to_sensor(pcb_to_spool));
 
 
+module rounded_square(size, center=false, r=0.0) {
+    width  = size[0] == undef ? size : size[0];  // unpack vector if present
+    height = size[1] == undef ? size : size[1];
+
+    if(r <= 0.0) {
+        square([width, height], center=center);
+    } else {
+        radius = min(min(r, width/2), height/2);  // radius cannot be larger than hole
+        center_x = center ? 0 : width/2;
+        center_y = center ? 0 : height/2;
+        fn = 30;
+
+        translate([center_x, center_y])
+            hull() {
+                x =  width/2 - radius;
+                y = height/2 - radius;
+
+                translate([ x,  y]) circle(r=radius, $fn=fn);
+                translate([ x, -y]) circle(r=radius, $fn=fn);
+                translate([-x, -y]) circle(r=radius, $fn=fn);
+                translate([-x,  y]) circle(r=radius, $fn=fn);
+            }
+    }
+}
+
+
 module standard_m4_bolt(nut_distance=-1) {
     if (render_bolts) {
         color(bolt_color)

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -231,6 +231,10 @@ zip_tie_width = 2.0;  // width of the zip-tie holes
 zip_tie_spacing = 6.5;  // spacing between each zip-tie hole, inside edges
 zip_tie_fillet = 0.5;  // radius of the rounded zip-tie hole corners
 
+enclosure_left_zip_side_inset = 5.0;  // inset from left for the bottom zip tie holes, edge to outside edge
+enclosure_left_zip_bottom_inset = 22.5;  // inset from bottom for the bottom zip tie holes, edge to group center
+
+
 echo(kerf_width=kerf_width);
 echo(enclosure_height=enclosure_height);
 echo(enclosure_height_upper=enclosure_height_upper);
@@ -641,6 +645,10 @@ module enclosure_left() {
                     }
                 }
             }
+
+            // Zip tie holes, sensor (leading to bottom)            
+            translate([enclosure_left_zip_bottom_inset, zip_tie_height/2 + enclosure_left_zip_side_inset, 0])
+                zip_tie_holes();
         }
     }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -265,7 +265,7 @@ module rounded_square(size, center=false, r=0.0, $fn=$fn) {
     if(r <= 0.0) {
         square([width, height], center=center);
     } else {
-        radius = min(min(r, width/2), height/2);  // radius cannot be larger than hole
+        radius = min(min(r, width/2), height/2);  // radius cannot be larger than rectangle
         center_x = center ? 0 : width/2;
         center_y = center ? 0 : height/2;
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -234,6 +234,8 @@ zip_tie_fillet = 0.5;  // radius of the rounded zip-tie hole corners
 enclosure_left_zip_side_inset = 5.0;  // inset from left for the bottom zip tie holes, edge to outside edge
 enclosure_left_zip_bottom_inset = 22.5;  // inset from bottom for the bottom zip tie holes, edge to group center
 
+enclosure_left_zip_top_inset = 22.5;  // inset from top for the top zip tie holes, edge to group center
+
 
 echo(kerf_width=kerf_width);
 echo(enclosure_height=enclosure_height);
@@ -649,6 +651,11 @@ module enclosure_left() {
             // Zip tie holes, sensor (leading to bottom)            
             translate([enclosure_left_zip_bottom_inset, zip_tie_height/2 + enclosure_left_zip_side_inset, 0])
                 zip_tie_holes();
+
+            // Zip tie holes, motor (leading to top)
+            translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length/2])
+                rotate([0, 0, 90])  // cable channel facing 'up'
+                    zip_tie_holes();
         }
     }
 }


### PR DESCRIPTION
Adds holes for cable management zip ties into the left side of the enclosure: one pair underneath the sensor PCB for wires exiting downwards (PCB behind module) and one pair above the motor for wires exiting upwards (PCB mounted on top of module(s)). The goal is to prevent the wires from bending outwards and getting tangled in the moving spools of adjacent modules.

These are sized to work with your typical 2.5 mm wide mini zip ties.

![sf-zip-tie-mounts png](https://user-images.githubusercontent.com/24282108/102036221-41980980-3d90-11eb-9b2a-437666906550.png)


