### PR TITLE
Character Reporting + Software Tweaks

### DIFF
--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -163,7 +163,11 @@ void setup() {
   Serial.print("\n\n\n");
   Serial.print(FAVR("{\"type\":\"init\", \"num_modules\":"));
   Serial.print(NUM_MODULES);
-  Serial.print(FAVR("}\n"));
+  Serial.print(FAVR(", \"character_list\":\""));
+  for(uint8_t i = 0; i < NUM_FLAPS; i++) {
+    Serial.print((char)flaps[i]);
+  }
+  Serial.print(FAVR("\"}\n"));
 
   for (uint8_t i = 0; i < NUM_MODULES; i++) {
     recv_buffer[i] = 0;

--- a/arduino/splitflap/Splitflap/src/spi_io_config.h
+++ b/arduino/splitflap/Splitflap/src/spi_io_config.h
@@ -99,7 +99,7 @@ BUFFER_ATTRS uint8_t sensor_buffer[SENSOR_BUFFER_LENGTH];
 #ifdef __AVR__
 // Define placement new so we can initialize SplitflapModules at runtime into a static buffer.
 // (see https://arduino.stackexchange.com/a/1499)
-void* operator new(size_t size, void* ptr) {
+void* operator new(__attribute__((unused)) size_t size, void* ptr) {
   return ptr;
 }
 #endif

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -85,7 +85,7 @@ class Splitflap(object):
                 letter,
                 list(self.character_list),
             )
-        self.last_command = text[0:self.num_modules]
+        self.last_command = text
         self.serial.write(b'=' + text.encode() + b'\n')
         return self._loop_for_status()
 

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -75,7 +75,7 @@ class Splitflap(object):
                 letter,
                 list(_ALPHABET),
             )
-        self.last_command = text
+        self.last_command = text[0:self.num_modules]
         self.serial.write(b'=' + text.encode() + b'\n')
         return self._loop_for_status()
 

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -80,6 +80,7 @@ class Splitflap(object):
         return self.character_list
 
     def set_text(self, text):
+        text = text[0:self.num_modules]  # trim to number of modules available
         for letter in text:
             assert self.in_character_list(letter), 'Unexpected letter: {!r}. Must be one of {!r}'.format(
                 letter,

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -76,6 +76,9 @@ class Splitflap(object):
     def in_character_list(self, letter):
         return letter in self.character_list
 
+    def get_character_list(self):
+        return self.character_list
+
     def set_text(self, text):
         for letter in text:
             assert self.in_character_list(letter), 'Unexpected letter: {!r}. Must be one of {!r}'.format(

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -21,6 +21,8 @@ class Splitflap(object):
 
         self.has_inited = False
         self.num_modules = 0
+        self.character_list = ""
+
         self.last_command = None
         self.last_status = None
         self.exception = None
@@ -41,6 +43,11 @@ class Splitflap(object):
                     raise RuntimeError('Unexpected re-init!')
                 self.has_inited = True
                 self.num_modules = data['num_modules']
+                try:
+                    self.character_list = data['character_list']
+                except KeyError:
+                    self.character_list = _ALPHABET  # for compatibility
+
             elif t == 'move_echo':
                 if not self.has_inited:
                     raise RuntimeError('Got move_echo before init!')
@@ -66,14 +73,14 @@ class Splitflap(object):
             else:
                 raise RuntimeError('Unexpected message: {!r}'.format(data))
 
-    def is_in_alphabet(self, letter):
-        return letter in _ALPHABET
+    def in_character_list(self, letter):
+        return letter in self.character_list
 
     def set_text(self, text):
         for letter in text:
-            assert self.is_in_alphabet(letter), 'Unexpected letter: {!r}. Must be one of {!r}'.format(
+            assert self.in_character_list(letter), 'Unexpected letter: {!r}. Must be one of {!r}'.format(
                 letter,
-                list(_ALPHABET),
+                list(self.character_list),
             )
         self.last_command = text[0:self.num_modules]
         self.serial.write(b'=' + text.encode() + b'\n')


### PR DESCRIPTION
A few small quality of life changes to the software:

#### Firmware:
* Prints the flap character array over serial (JSON) during initialization.
* Adds an `__unused__` attribute to the `new` operator override used for static placement of the module objects, which was creating a warning during compilation.

#### Scripts:
* Reads the reported flap character array if present during initialization, and uses that instead of `_ALPHABET` to filter characters. This allows the Python script to talk to displays with any character set without having to modify the script's array. Includes a `KeyError` catch to support previous firmware that does not report its character set.
* Truncates the text being sent (`set_text()`) to the size of the display (number of modules). This prevents verification issues when the number of modules in the firmware is smaller than the length of the text being sent, as the firmware's buffer will also truncate the string.