### PR TITLE
Alignment Indicators

### DIFF
--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -39,11 +39,8 @@ module rounded_square(size, center=false, r=0.0, $fn=$fn) {
 }
 
 module triangle(size, center=false) {
-    function tri_height(a, c) = sqrt(c*c - a*a);  // pythagoras
-
     width  = size[0] == undef ? size : size[0];  // unpack vector if present
-    height = size[1] == undef ? tri_height(width/2, width) : size[1];  // calculate height with trig if only width provided
-    angle = atan(height/(width/2));  // angle in left corner, degrees
+    height = size[1] == undef ? size : size[1];
 
     pts = [
         [      0,      0],
@@ -52,7 +49,7 @@ module triangle(size, center=false) {
     ];
 
     x_offset = center ?  -width/2 : 0;
-    y_offset = center ? -tan(angle/2) * width/2 : 0;  // opposite edge of right triangle using bisected angle from left corner
+    y_offset = center ? -height/2 : 0;
     translate([x_offset, y_offset])
         polygon(points=pts, convexity=1);
 }

--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -56,3 +56,21 @@ module triangle(size, center=false) {
     translate([x_offset, y_offset])
         polygon(points=pts, convexity=1);
 }
+
+module arrow(size, aspect=[0.5, 0.3], center=false) {
+    function unpack(val, pos) = val[pos] == undef ? val : val[pos];  // use vector if possible, value otherwise
+    function recenter(vect, pos) = center ? -vect[pos]/2 : 0;  // if 'center', return negative vector position/2
+
+    size  = [   unpack(size, 0),   unpack(size, 1) ];  // overall bounding box
+    ratio = [ unpack(aspect, 0), unpack(aspect, 1) ];  // ratio between head and body, 1.0 max
+
+    head = [                  size[0], size[1] * ratio[1] ];  // head bounding box
+    base = [ size[0] * (1 - ratio[0]), size[1] - head[1]  ];  // base bounding box
+
+    translate([recenter(size, 0), recenter(size, 1)]) {
+        translate([(size[0] - base[0]) / 2, 0])
+            square(base);
+        translate([0, base[1]])
+            triangle(head);
+    }
+}

--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -1,0 +1,58 @@
+/*
+   Copyright 2020 Scott Bezek and the splitflap contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+module rounded_square(size, center=false, r=0.0, $fn=$fn) {
+    width  = size[0] == undef ? size : size[0];  // unpack vector if present
+    height = size[1] == undef ? size : size[1];
+
+    if(r <= 0.0) {
+        square([width, height], center=center);
+    } else {
+        radius = min(min(r, width/2), height/2);  // radius cannot be larger than rectangle
+        center_x = center ? 0 : width/2;
+        center_y = center ? 0 : height/2;
+
+        translate([center_x, center_y])
+            hull() {
+                x =  width/2 - radius;
+                y = height/2 - radius;
+
+                translate([ x,  y]) circle(r=radius, $fn=$fn);
+                translate([ x, -y]) circle(r=radius, $fn=$fn);
+                translate([-x, -y]) circle(r=radius, $fn=$fn);
+                translate([-x,  y]) circle(r=radius, $fn=$fn);
+            }
+    }
+}
+
+module triangle(size, center=false) {
+    function tri_height(a, c) = sqrt(c*c - a*a);  // pythagoras
+
+    width  = size[0] == undef ? size : size[0];  // unpack vector if present
+    height = size[1] == undef ? tri_height(width/2, width) : size[1];  // calculate height with trig if only width provided
+    angle = atan(height/(width/2));  // angle in left corner, degrees
+
+    pts = [
+        [      0,      0],
+        [width/2, height],
+        [  width,      0],
+    ];
+
+    x_offset = center ?  -width/2 : 0;
+    y_offset = center ? -tan(angle/2) * width/2 : 0;  // opposite edge of right triangle using bisected angle from left corner
+    translate([x_offset, y_offset])
+        polygon(points=pts, convexity=1);
+}

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -519,25 +519,15 @@ module enclosure_front() {
 }
 
 module enclosure_front_etch() {
-    // alignment indicators, left side (triangle)
-    enclosure_etch_style() {
-        translate([enclosure_wall_to_wall_width - thickness - enclosure_indicator_inset, 0]) {
-            translate([0, enclosure_indicator_position_y])
-                triangle(enclosure_indicator_size, center=true);  // top
-            translate([0, enclosure_height - enclosure_indicator_position_y])
-                triangle(enclosure_indicator_size, center=true);  // bottom
-        }
-    }
+    // alignment indicator, left side (triangle)
+    enclosure_etch_style()
+        translate([enclosure_wall_to_wall_width - thickness - enclosure_indicator_inset, enclosure_indicator_position_y])
+            triangle(enclosure_indicator_size, center=true);
 
-    // alignment indicators, right side (circle)
-    enclosure_etch_style() {
-        translate([thickness + enclosure_indicator_inset, 0]) {
-            translate([0, enclosure_indicator_position_y])
-                circle(r=enclosure_indicator_size/2, $fn=60);  // top
-            translate([0, enclosure_height - enclosure_indicator_position_y])
-                circle(r=enclosure_indicator_size/2, $fn=60);  // bottom
-        }
-    }
+    // alignment indicator, right side (circle)
+    enclosure_etch_style()
+        translate([thickness + enclosure_indicator_inset, enclosure_indicator_position_y])
+            circle(r=enclosure_indicator_size/2, $fn=60);
 
     // position indicator, 'up' arrow
     enclosure_etch_style()
@@ -646,16 +636,11 @@ module enclosure_left() {
 }
 
 module enclosure_left_etch() {
-    // alignment indicators (triangle)
-    enclosure_etch_style() {
-        translate([0, enclosure_length - enclosure_indicator_inset])
-            rotate([0, 0, -90]) {
-                translate([0, enclosure_indicator_position_y])
-                    triangle(enclosure_indicator_size, center=true);  // top
-                translate([0, enclosure_height - enclosure_indicator_position_y])
-                    triangle(enclosure_indicator_size, center=true);  // bottom
-            }
-    }
+    // alignment indicator (triangle)
+    enclosure_etch_style()
+        translate([enclosure_indicator_position_y, enclosure_length - enclosure_indicator_inset])
+            rotate([0, 0, -90])
+                triangle(enclosure_indicator_size, center=true);
 }
 
 module shaft_centered_motor_hole() {
@@ -703,15 +688,10 @@ module enclosure_right() {
 }
 
 module enclosure_right_etch() {
-    // alignment indicators (circle)
-    enclosure_etch_style() {
-        translate([0, enclosure_length_right - enclosure_indicator_inset]) {
-            translate([enclosure_height - enclosure_indicator_position_y, 0])
-                circle(r=enclosure_indicator_size/2, $fn=60);  // top
-            translate([enclosure_indicator_position_y, 0])
-                circle(r=enclosure_indicator_size/2, $fn=60);  // bottom
-        }
-    }
+    // alignment indicator (circle)
+    enclosure_etch_style()
+        translate([enclosure_height - enclosure_indicator_position_y, enclosure_length_right - enclosure_indicator_inset])
+            circle(r=enclosure_indicator_size/2, $fn=60);
 }
 
 module front_back_tabs() {

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1156,24 +1156,24 @@ if (render_3d) {
             enclosure_left();
 
         laser_etch()
-        translate([0, 0])
-            enclosure_left_etch();
+            translate([0, 0])
+                enclosure_left_etch();
 
         translate([0, enclosure_length + kerf_width])
             enclosure_right();
 
         laser_etch()
-        translate([0, enclosure_length + kerf_width])
-            enclosure_right_etch();
+            translate([0, enclosure_length + kerf_width])
+                enclosure_right_etch();
 
         translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
             rotate([0, 0, -90])
                 enclosure_front();
 
         laser_etch()
-        translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
-            rotate([0, 0, -90])
-                enclosure_front_etch();
+            translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
+                rotate([0, 0, -90])
+                    enclosure_front_etch();
 
         // Top and bottom
         translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -229,6 +229,8 @@ mounting_hole_inset = m4_button_head_diameter/2 + 2;
 
 enclosure_indicator_inset = 3.0;  // inset on both X and Y
 enclosure_indicator_size = 1.75;  // symbol size
+enclosure_indicator_arrow_width = 2.25;
+enclosure_indicator_arrow_height = enclosure_indicator_arrow_width * 2;
 enclosure_indicator_position_y = (enclosure_height - enclosure_vertical_inset - thickness) - enclosure_indicator_inset;
 
 echo(kerf_width=kerf_width);
@@ -526,6 +528,11 @@ module enclosure_front_etch() {
     enclosure_etch_style()
         translate([thickness + enclosure_indicator_inset, enclosure_indicator_position_y])
             circle(r=enclosure_indicator_size/2, $fn=60);
+
+    // position indicator, 'up' arrow
+    enclosure_etch_style()
+        translate([enclosure_width - enclosure_horizontal_inset * 1.5, enclosure_height - enclosure_indicator_arrow_height/2 - enclosure_indicator_inset])
+            arrow([enclosure_indicator_arrow_width, enclosure_indicator_arrow_height], center=true);
 }
 
 // holes for 28byj-48 motor, centered around motor shaft

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -76,6 +76,7 @@ kerf_width = 0.2 - 0.02;
 // https://www.ponoko.com/materials/mdf-fiberboard
 thickness = 3.0;
 
+etch_depth = 0.1;  // for render
 eps=.01;
 
 captive_nut_inset=6;
@@ -154,7 +155,6 @@ spool_strut_tab_outset=8;
 spool_strut_width = (spool_strut_tab_outset + thickness/2) * 2;
 spool_strut_length = spool_width;
 spool_strut_inner_length = spool_width - 3 * thickness;
-spool_etch_depth = 0.1;  // for 3D render
 
 spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_strut_tab_outset+thickness/2) + (spool_strut_tab_width/2)*(spool_strut_tab_width/2));
 
@@ -369,7 +369,7 @@ module flap_spool_complete(captive_nut=false, motor_shaft=false, magnet_hole=fal
 
 module flap_spool_etch() {
     color(etch_color)
-    flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset, spool_etch_depth);
+    flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset, etch_depth);
 }
 
 module spool_retaining_wall(m4_bolt_hole=false) {
@@ -489,7 +489,7 @@ module connector_bracket() {
 module enclosure_etch_style() {
     color(etch_color)
         translate([0, 0, thickness])
-            linear_extrude(height=0.1)
+            linear_extrude(height=etch_depth)
                 children();
 }
 
@@ -1091,7 +1091,7 @@ module split_flap_3d(letter, include_connector) {
                     difference() {
                         color(assembly_color)
                             flap_spool_complete(captive_nut=true);
-                        translate([0, 0, -spool_etch_depth + thickness + eps])
+                        translate([0, 0, -etch_depth + thickness + eps])
                             flap_spool_etch();
                     }
                 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -813,12 +813,10 @@ module enclosure_bottom() {
 }
 
 module enclosure_bottom_etch() {
-    color(etch_color)
-    linear_extrude(height=2, center=true) {
+    enclosure_etch_style()
         translate([captive_nut_inset + m4_nut_length + 1, 1, thickness]) {
             text_label([str("rev. ", render_revision), render_date, "github.com/scottbez1/splitflap"]);
         }
-    }
 }
 
 module split_flap_3d(letter, include_connector) {
@@ -876,18 +874,19 @@ module split_flap_3d(letter, include_connector) {
                 enclosure_top();
     }
 
+    module position_bottom() {
+        translate([0, front_forward_offset - enclosure_length_right, -enclosure_height_lower + enclosure_vertical_inset])
+            children();
+    }
+
     module positioned_bottom() {
-        translate([0, front_forward_offset - enclosure_length_right, -enclosure_height_lower + enclosure_vertical_inset]) {
+        position_bottom()
             enclosure_bottom();
-        }
     }
 
     module positioned_bottom_etch() {
-        translate([0, front_forward_offset - enclosure_length_right, -enclosure_height_lower + enclosure_vertical_inset]) {
-            translate([0, 0, thickness]) {
-                enclosure_bottom_etch();
-            }
-        }
+        position_bottom()
+            enclosure_bottom_etch();
     }
 
     module positioned_top_connector() {
@@ -1183,7 +1182,7 @@ if (render_3d) {
 
         // Bottom laser etching
         laser_etch()
-            translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width, thickness])
+            translate([enclosure_height + kerf_width, enclosure_wall_to_wall_width])
                 rotate([0, 0, -90])
                     enclosure_bottom_etch();
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -368,8 +368,8 @@ module flap_spool_complete(captive_nut=false, motor_shaft=false, magnet_hole=fal
 }
 
 module flap_spool_etch() {
-    color(etch_color)
-    flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset, etch_depth);
+    enclosure_etch_style()
+        flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset);
 }
 
 module spool_retaining_wall(m4_bolt_hole=false) {
@@ -1071,12 +1071,10 @@ module split_flap_3d(letter, include_connector) {
             // motor spool
             translate([spool_width - thickness + 5*spool_horizontal_explosion, 0, 0]) {
                 rotate([0, 90, 0]) {
-                    difference() {
-                        color(assembly_color)
-                            flap_spool_complete(motor_shaft=true, magnet_hole=true);
-                        translate([0, 0, -eps])
-                            flap_spool_etch();
-                    }
+                    color(assembly_color)
+                        flap_spool_complete(motor_shaft=true, magnet_hole=true);
+                    translate([0, 0, -eps - thickness])
+                        flap_spool_etch();
                 }
             }
             color(assembly_color1) {
@@ -1088,12 +1086,9 @@ module split_flap_3d(letter, include_connector) {
             }
             translate([-5*spool_horizontal_explosion, 0, 0]) {
                 rotate([0, 90, 0]) {
-                    difference() {
-                        color(assembly_color)
-                            flap_spool_complete(captive_nut=true);
-                        translate([0, 0, -etch_depth + thickness + eps])
-                            flap_spool_etch();
-                    }
+                    color(assembly_color)
+                        flap_spool_complete(captive_nut=true);
+                    flap_spool_etch();
                 }
             }
             translate([thickness * 2, 0, 0]) {
@@ -1220,10 +1215,10 @@ if (render_3d) {
 
         // Flap spool etching
         laser_etch() {
-            translate([flap_spool_x_off, flap_spool_y_off, thickness])
+            translate([flap_spool_x_off, flap_spool_y_off])
                 mirror([0, 1, 0])
                 flap_spool_etch();
-            translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off, thickness])
+            translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
                 flap_spool_etch();
         }
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -690,7 +690,7 @@ module enclosure_right() {
 module enclosure_right_etch() {
     // alignment indicator (circle)
     enclosure_etch_style()
-        translate([enclosure_vertical_inset + thickness + enclosure_indicator_inset, enclosure_length_right - enclosure_indicator_inset])
+        translate([enclosure_height - enclosure_indicator_position_y, enclosure_length_right - enclosure_indicator_inset])
             circle(r=enclosure_indicator_size/2, $fn=60);
 }
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -20,6 +20,7 @@ use<projection_renderer.scad>;
 use<roboto/RobotoCondensed-Regular.ttf>;
 use<rough7380.scad>;
 use<spool.scad>;
+use<shapes.scad>;
 
 include<28byj-48.scad>;
 include<flap_dimensions.scad>;
@@ -516,15 +517,15 @@ module enclosure_front() {
 }
 
 module enclosure_front_etch() {
-    // alignment indicator, left side (circle)
+    // alignment indicator, left side (triangle)
     enclosure_etch_style()
         translate([enclosure_wall_to_wall_width - thickness - enclosure_indicator_inset, enclosure_indicator_position_y])
-            circle(r=enclosure_indicator_size/2, $fn=60);
+            triangle(enclosure_indicator_size, center=true);
 
-    // alignment indicator, right side (square)
+    // alignment indicator, right side (circle)
     enclosure_etch_style()
         translate([thickness + enclosure_indicator_inset, enclosure_indicator_position_y])
-            square(enclosure_indicator_size, center=true);
+            circle(r=enclosure_indicator_size/2, $fn=60);
 }
 
 // holes for 28byj-48 motor, centered around motor shaft
@@ -628,10 +629,11 @@ module enclosure_left() {
 }
 
 module enclosure_left_etch() {
-    // alignment indicator (circle)
+    // alignment indicator (triangle)
     enclosure_etch_style()
         translate([enclosure_indicator_position_y, enclosure_length - enclosure_indicator_inset])
-            circle(r=enclosure_indicator_size/2, $fn=60);
+            rotate([0, 0, -90])
+                triangle(enclosure_indicator_size, center=true);
 }
 
 module shaft_centered_motor_hole() {
@@ -679,10 +681,10 @@ module enclosure_right() {
 }
 
 module enclosure_right_etch() {
-    // alignment indicator (square)
+    // alignment indicator (circle)
     enclosure_etch_style()
         translate([enclosure_vertical_inset + thickness + enclosure_indicator_inset, enclosure_length_right - enclosure_indicator_inset])
-            square(enclosure_indicator_size, center=true);
+            circle(r=enclosure_indicator_size/2, $fn=60);
 }
 
 module front_back_tabs() {

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -519,15 +519,25 @@ module enclosure_front() {
 }
 
 module enclosure_front_etch() {
-    // alignment indicator, left side (triangle)
-    enclosure_etch_style()
-        translate([enclosure_wall_to_wall_width - thickness - enclosure_indicator_inset, enclosure_indicator_position_y])
-            triangle(enclosure_indicator_size, center=true);
+    // alignment indicators, left side (triangle)
+    enclosure_etch_style() {
+        translate([enclosure_wall_to_wall_width - thickness - enclosure_indicator_inset, 0]) {
+            translate([0, enclosure_indicator_position_y])
+                triangle(enclosure_indicator_size, center=true);  // top
+            translate([0, enclosure_height - enclosure_indicator_position_y])
+                triangle(enclosure_indicator_size, center=true);  // bottom
+        }
+    }
 
-    // alignment indicator, right side (circle)
-    enclosure_etch_style()
-        translate([thickness + enclosure_indicator_inset, enclosure_indicator_position_y])
-            circle(r=enclosure_indicator_size/2, $fn=60);
+    // alignment indicators, right side (circle)
+    enclosure_etch_style() {
+        translate([thickness + enclosure_indicator_inset, 0]) {
+            translate([0, enclosure_indicator_position_y])
+                circle(r=enclosure_indicator_size/2, $fn=60);  // top
+            translate([0, enclosure_height - enclosure_indicator_position_y])
+                circle(r=enclosure_indicator_size/2, $fn=60);  // bottom
+        }
+    }
 
     // position indicator, 'up' arrow
     enclosure_etch_style()
@@ -636,11 +646,16 @@ module enclosure_left() {
 }
 
 module enclosure_left_etch() {
-    // alignment indicator (triangle)
-    enclosure_etch_style()
-        translate([enclosure_indicator_position_y, enclosure_length - enclosure_indicator_inset])
-            rotate([0, 0, -90])
-                triangle(enclosure_indicator_size, center=true);
+    // alignment indicators (triangle)
+    enclosure_etch_style() {
+        translate([0, enclosure_length - enclosure_indicator_inset])
+            rotate([0, 0, -90]) {
+                translate([0, enclosure_indicator_position_y])
+                    triangle(enclosure_indicator_size, center=true);  // top
+                translate([0, enclosure_height - enclosure_indicator_position_y])
+                    triangle(enclosure_indicator_size, center=true);  // bottom
+            }
+    }
 }
 
 module shaft_centered_motor_hole() {
@@ -688,10 +703,15 @@ module enclosure_right() {
 }
 
 module enclosure_right_etch() {
-    // alignment indicator (circle)
-    enclosure_etch_style()
-        translate([enclosure_height - enclosure_indicator_position_y, enclosure_length_right - enclosure_indicator_inset])
-            circle(r=enclosure_indicator_size/2, $fn=60);
+    // alignment indicators (circle)
+    enclosure_etch_style() {
+        translate([0, enclosure_length_right - enclosure_indicator_inset]) {
+            translate([enclosure_height - enclosure_indicator_position_y, 0])
+                circle(r=enclosure_indicator_size/2, $fn=60);  // top
+            translate([enclosure_indicator_position_y, 0])
+                circle(r=enclosure_indicator_size/2, $fn=60);  // bottom
+        }
+    }
 }
 
 module front_back_tabs() {

--- a/3d/spool.scad
+++ b/3d/spool.scad
@@ -37,7 +37,7 @@ module flap_spool(flaps, flap_hole_radius, flap_hole_separation, outset, height)
     }
 }
 
-module flap_spool_home_indicator(flaps, flap_hole_radius, flap_hole_separation, outset, height) {
+module flap_spool_home_indicator(flaps, flap_hole_radius, flap_hole_separation, outset, height=0) {
     pitch_radius = flap_spool_pitch_radius(flaps, flap_hole_radius, flap_hole_separation);
     outer_radius = flap_spool_outer_radius(flaps, flap_hole_radius, flap_hole_separation, outset);
 


### PR DESCRIPTION
Adds alignment indicators to the enclosure to aid in assembly: a triangle on the left side, a circle on the right side, and an 'up' arrow on the front face. The goal is to provide an easy visual cue for how the enclosure pieces fit together - particularly the front piece, which is slightly asymmetric. I opted not to add indicators to the top and bottom pieces because they seemed a little redundant.

The triangle and arrow geometry were added through modules included in a new `shapes.scad` file. This also includes the rounded rectangle module that was submitted separately as a part of PR #109 (Zip Ties).

I also cleaned up the other etched features in the design and removed the 3D difference feature for the etched spool indicators which struck me as excessive. All etched features now go through a single helper function to set the positional offset, height, and color.

#### Ponoko Quotes (3.0 mm MDF, 2020-12-21):

| Branch                 | Variant                          | Commit  | Price  |
|------------------------|----------------------------------|---------|--------|
| `master`               |                                  | 0f6d8b7 | $20.29 |
| `alignment-indicators` | one-ended (submitted)    | 71fcfb8 | $20.85 |
| `alignment-indicators` | two-ended                         | 9e60870 | $24.80 |
| `alignment-indicators` | two-ended , line-etched, no label | 9e60870    | $21.55 |

This submitted version only has the one-ended indicators, which add $0.56 USD to the cost of each enclosure or an increase of 2.7%. In my opinion the symmetry of the two-ended indicators looks much better but is not worth the cost increase.

I'm suspecting the large jump in price comes down to how the laser-etching process works. When I used to operate a laser the software would rasterize the design and then run the head back and forth horizontally at a steady pace over all areas with etched items, firing the laser itself only over etched areas. Because the pair of alignment indicators are lined up horizontally the laser is likely performing a continuous slow travel move over the height of the front panel, which would increase the time to cut the design and explain the jump in cost.

For good measure I also tested the two-ended version without the text label and with line-etching instead of area etching, which would presumably reduce the travel time costs but increase the cost of etching itself. Even so, it would still be cheaper to keep the label and use area engraving with one-ended indicators - which is what is submitted.

#### Photos:

![sf-alignment-ind-normal](https://user-images.githubusercontent.com/24282108/102844535-a9c29d00-43d9-11eb-8ee6-0e57ca9c08c7.png)

![sf-alignment-ind-right](https://user-images.githubusercontent.com/24282108/102844539-ab8c6080-43d9-11eb-826c-c32a8664e9ac.png)

![sf-alignment-ind-left](https://user-images.githubusercontent.com/24282108/102844544-ad562400-43d9-11eb-9a50-c91fa171e5cb.png)

![sf-alignment-ind-flat](https://user-images.githubusercontent.com/24282108/102844708-fc03be00-43d9-11eb-95a2-db97f7863511.png)