### PR TITLE
Spool Letter Rendering

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1068,7 +1068,9 @@ module split_flap_3d(letter, include_connector) {
                             translate([flap_width, flap_pitch_radius, 0]) {
                                 rotate([flap_rendered_angle, 0, 180]) {
                                     flap();
-                                    if((i == 0 && render_letters == 1) || render_letters == 2)
+                                    if(i == 0 && render_letters >= 1)  // for first flap, do not use character list (always match string)
+                                        flap_letter(letter, 1);  // flap on front (top)
+                                    if(i != 0 && render_letters == 2)
                                         flap_letter(get_flap_character(letter, i), 1);  // flap on front (top)
                                     if(render_letters == 2) {
                                         translate([flap_width, 0, -flap_thickness + eps])
@@ -1088,7 +1090,9 @@ module split_flap_3d(letter, include_connector) {
                         if (i == 1 || render_flaps == 2) {
                             rotate([-90, 0, 0]) {
                                 flap();
-                                if((i == 1 && render_letters == 1) || render_letters == 2)
+                                if(i == 1 && render_letters >= 1)  // for first flap, do not use character list (always match string)
+                                    flap_letter(letter, 2);  // flap on front (bottom)
+                                if(i != 1 && render_letters == 2)
                                     flap_letter(get_flap_character(letter, len(character_list) - i + 1), 2);  // flap on front (bottom)
                                 if(render_letters == 2) {
                                     translate([flap_width, 0, -flap_thickness + eps])

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -1007,11 +1007,11 @@ module split_flap_3d(letter, include_connector) {
                             rotate([-90, 0, 0]) {
                                 flap();
                                 if((i == 1 && render_letters == 1) || render_letters == 2)
-                                    flap_letter(get_flap_character(letter, num_flaps - i + 1), 2);  // flap on front (top)
+                                    flap_letter(get_flap_character(letter, len(character_list) - i + 1), 2);  // flap on front (top)
                                 if(render_letters == 2) {
                                     translate([flap_width, 0, -flap_thickness + eps])
                                         mirror([1, 0, 0])
-                                            flap_letter(get_flap_character(letter, num_flaps - i), 1);  // flap on back (bottom)
+                                            flap_letter(get_flap_character(letter, len(character_list) - i), 1);  // flap on back (bottom)
                                 }
                             }
                         }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -246,7 +246,8 @@ function character_position(c, i=0, list=character_list) =
 
 // returns character in array position, assuming the array loops around
 function character_loop(pos, list=character_list) =
-    pos >= len(list) ? character_loop(pos - len(list), list)
+      pos < 0 ? character_loop(pos + len(list), list)  // negative, add until positive
+    : pos >= len(list) ? character_loop(pos - len(list), list) // out of range, subtract until in
     : pos == undef ? " "  // invalid character, return space
     : list[pos];
 
@@ -1093,11 +1094,11 @@ module split_flap_3d(letter, include_connector) {
                                 if(i == 1 && render_letters >= 1)  // for first flap, do not use character list (always match string)
                                     flap_letter(letter, 2);  // flap on front (bottom)
                                 if(i != 1 && render_letters == 2)
-                                    flap_letter(get_flap_character(letter, len(character_list) - i + 1), 2);  // flap on front (bottom)
+                                    flap_letter(get_flap_character(letter, -i + 1), 2);  // flap on front (bottom)
                                 if(render_letters == 2) {
                                     translate([flap_width, 0, -flap_thickness + eps])
                                         mirror([1, 0, 0])
-                                            flap_letter(get_flap_character(letter, len(character_list) - i), 1);  // flap on back (top)
+                                            flap_letter(get_flap_character(letter, -i), 1);  // flap on back (top)
                                 }
                             }
                         }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -35,8 +35,8 @@ render_3d = true;
 render_enclosure = 2; // 0=invisible; 1=translucent; 2=opaque color;
 render_flaps = 2; // 0=invisible; 1=front flap only; 2=all flaps
 render_flap_area = 0; // 0=invisible; 1=collapsed flap exclusion; 2=collapsed+extended flap exclusion
-render_letters = "44";
-render_units = len(render_letters);
+render_string = "44";
+render_units = len(render_string);
 render_unit_separation = 0;
 render_spool = true;
 render_pcb = true;
@@ -1092,7 +1092,7 @@ module laser_etch() {
 if (render_3d) {
     for (i = [0 : render_units - 1]) {
         translate([-enclosure_width/2 + (-(render_units-1) / 2 + i)*(enclosure_width + render_unit_separation), 0, 0])
-            split_flap_3d(render_letters[render_units - 1 - i], include_connector=(i != render_units - 1));
+            split_flap_3d(render_string[render_units - 1 - i], include_connector=(i != render_units - 1));
     }
 } else {
     panel_height = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width + kerf_width + spool_strut_width + kerf_width;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -244,13 +244,13 @@ function character_position(c, i=0, list=character_list) =
     : list[i] == c ? i
     : character_position(c, i+1, list);
 
-// returns character in array position, assuming it loops
+// returns character in array position, assuming the array loops around
 function character_loop(pos, list=character_list) =
     pos >= len(list) ? character_loop(pos - len(list), list)
     : pos == undef ? " "  // invalid character, return space
     : list[pos];
 
-// for the display number and flap position, returns the relevant character in the spool
+// for the starting letter and flap position, returns the relevant character in the spool
 function get_flap_character(letter, flap, list=character_list) =
     character_loop(character_position(letter) + flap, list);
 
@@ -1089,11 +1089,11 @@ module split_flap_3d(letter, include_connector) {
                             rotate([-90, 0, 0]) {
                                 flap();
                                 if((i == 1 && render_letters == 1) || render_letters == 2)
-                                    flap_letter(get_flap_character(letter, len(character_list) - i + 1), 2);  // flap on front (top)
+                                    flap_letter(get_flap_character(letter, len(character_list) - i + 1), 2);  // flap on front (bottom)
                                 if(render_letters == 2) {
                                     translate([flap_width, 0, -flap_thickness + eps])
                                         mirror([1, 0, 0])
-                                            flap_letter(get_flap_character(letter, len(character_list) - i), 1);  // flap on back (bottom)
+                                            flap_letter(get_flap_character(letter, len(character_list) - i), 1);  // flap on back (top)
                                 }
                             }
                         }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -35,7 +35,7 @@ render_3d = true;
 render_enclosure = 2; // 0=invisible; 1=translucent; 2=opaque color;
 render_flaps = 2; // 0=invisible; 1=front flap only; 2=all flaps
 render_flap_area = 0; // 0=invisible; 1=collapsed flap exclusion; 2=collapsed+extended flap exclusion
-render_letters = 1;  // 0=invisible; 1=front flap only; 2=all flaps
+render_letters = 2;  // 0=invisible; 1=front flap only; 2=all flaps
 render_string = "44";
 render_units = len(render_string);
 render_unit_separation = 0;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -226,6 +226,26 @@ connector_bracket_depth_clearance = 0.20;
 
 mounting_hole_inset = m4_button_head_diameter/2 + 2;
 
+
+character_list = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,\\";
+
+// returns character position in an array
+function character_position(c, i=0, list=character_list) =
+    len(list) == i ? undef
+    : list[i] == c ? i
+    : character_position(c, i+1, list);
+
+// returns character in array position, assuming it loops
+function character_loop(pos, list=character_list) =
+    pos >= len(list) ? character_loop(pos - len(list), list)
+    : pos == undef ? " "  // invalid character, return space
+    : list[pos];
+
+// for the display number and flap position, returns the relevant character in the spool
+function get_flap_character(letter, flap, list=character_list) =
+    character_loop(character_position(letter) + flap, list);
+
+
 echo(kerf_width=kerf_width);
 echo(enclosure_height=enclosure_height);
 echo(enclosure_height_upper=enclosure_height_upper);
@@ -965,9 +985,10 @@ module split_flap_3d(letter, include_connector) {
                             translate([flap_width, flap_pitch_radius, 0]) {
                                 rotate([flap_rendered_angle, 0, 180]) {
                                     flap();
-                                    if (i == 0) { 
-                                        flap_letter(letter, 1);  // 1 = top
-                                    }
+                                    flap_letter(get_flap_character(letter, i), 1);  // flap on front (top)
+                                    translate([flap_width, 0, -flap_thickness + eps])
+                                        mirror([1, 0, 0])
+                                            flap_letter(get_flap_character(letter, i+1), 2);  // flap on back (bottom)
                                 }
                             }
                         }
@@ -981,9 +1002,10 @@ module split_flap_3d(letter, include_connector) {
                         if (i == 1 || render_flaps == 2) {
                             rotate([-90, 0, 0]) {
                                 flap();
-                                if (i == 1) {
-                                    flap_letter(letter, 2);  // 2 = bottom
-                                }
+                                flap_letter(get_flap_character(letter, num_flaps - i + 1), 2);  // flap on front (top)
+                                translate([flap_width, 0, -flap_thickness + eps])
+                                    mirror([1, 0, 0])
+                                        flap_letter(get_flap_character(letter, num_flaps - i), 1);  // flap on back (bottom)
                             }
                         }
                     }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -35,6 +35,7 @@ render_3d = true;
 render_enclosure = 2; // 0=invisible; 1=translucent; 2=opaque color;
 render_flaps = 2; // 0=invisible; 1=front flap only; 2=all flaps
 render_flap_area = 0; // 0=invisible; 1=collapsed flap exclusion; 2=collapsed+extended flap exclusion
+render_letters = 1;  // 0=invisible; 1=front flap only; 2=all flaps
 render_string = "44";
 render_units = len(render_string);
 render_unit_separation = 0;
@@ -985,10 +986,13 @@ module split_flap_3d(letter, include_connector) {
                             translate([flap_width, flap_pitch_radius, 0]) {
                                 rotate([flap_rendered_angle, 0, 180]) {
                                     flap();
-                                    flap_letter(get_flap_character(letter, i), 1);  // flap on front (top)
-                                    translate([flap_width, 0, -flap_thickness + eps])
-                                        mirror([1, 0, 0])
-                                            flap_letter(get_flap_character(letter, i+1), 2);  // flap on back (bottom)
+                                    if((i == 0 && render_letters == 1) || render_letters == 2)
+                                        flap_letter(get_flap_character(letter, i), 1);  // flap on front (top)
+                                    if(render_letters == 2) {
+                                        translate([flap_width, 0, -flap_thickness + eps])
+                                            mirror([1, 0, 0])
+                                                flap_letter(get_flap_character(letter, i+1), 2);  // flap on back (bottom)
+                                    }
                                 }
                             }
                         }
@@ -1002,10 +1006,13 @@ module split_flap_3d(letter, include_connector) {
                         if (i == 1 || render_flaps == 2) {
                             rotate([-90, 0, 0]) {
                                 flap();
-                                flap_letter(get_flap_character(letter, num_flaps - i + 1), 2);  // flap on front (top)
-                                translate([flap_width, 0, -flap_thickness + eps])
-                                    mirror([1, 0, 0])
-                                        flap_letter(get_flap_character(letter, num_flaps - i), 1);  // flap on back (bottom)
+                                if((i == 1 && render_letters == 1) || render_letters == 2)
+                                    flap_letter(get_flap_character(letter, num_flaps - i + 1), 2);  // flap on front (top)
+                                if(render_letters == 2) {
+                                    translate([flap_width, 0, -flap_thickness + eps])
+                                        mirror([1, 0, 0])
+                                            flap_letter(get_flap_character(letter, num_flaps - i), 1);  // flap on back (bottom)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Over-the-top update: this change renders flap letters on both the front and back of *all* flaps in the spool. The program calculates the position of the front-facing letter in the character list, and then adds each front/back letter by iterating through the looped array starting at that point. If the front-facing letter is not present in the character list, only the front letter is rendered and the rest of the spool letters are skipped. This is evaluated per-module so each spool's flaps will have the correct letters in their correct positions.

The existing `render_letters` value has been refactored as `render_string`. The new `render_letters` value controls visibility of the letters themselves: `0` for no letters, `1` for front letters, `2` for all letters. This matches the behavior of the other visibility control options. By default all letters are rendered.

The character set is the same as the the current firmware (` ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,\`). With Roboto the comma looks a little off as it's visible when hanging below the front flap, but otherwise everything looks as expected.

This serves little functional purpose, but it adds a nice bit of polish to the design + render. My goal was to export the assembly into Blender with all letters using `generate_stl.py`, which works a treat:

#### OpenSCAD:
![sf-spool-letters-scad](https://user-images.githubusercontent.com/24282108/102947779-1a2cf500-4492-11eb-94b7-4acf914f57a2.png)

#### Blender 2.91 (Cycles):
![sf-spool-letters-render](https://user-images.githubusercontent.com/24282108/102948867-e0112280-4494-11eb-83fd-5d3962045594.png)

