### PR TITLE
CAD: Move flap thickness slop to spool slop

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -117,7 +117,7 @@ letter_color = color_invert(flap_color);  // inverse of the flap color, for cont
 flap_rendered_angle = 90;
 
 
-flap_width_slop = 0.1;  // amount of slop of the flap side to side between the 2 spools
+flap_width_slop = 0.15;  // amount of slop of the flap side to side between the 2 spools
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -117,9 +117,9 @@ letter_color = color_invert(flap_color);  // inverse of the flap color, for cont
 flap_rendered_angle = 90;
 
 
-flap_width_slop = 0.5;  // amount of slop of the flap side to side between the 2 spools
+flap_width_slop = 0.1;  // amount of slop of the flap side to side between the 2 spools
 
-spool_width_slop = 1;  // amount of slop for the spool assembly side-to-side inside the enclosure
+spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 
 spool_tab_clearance = -0.02;  // for the tabs connecting the struts to the spool ends (interference fit)
 spool_retaining_clearance = 0.10;  // for the notches in the spool retaining wall


### PR DESCRIPTION
This increase was a mistake. The difference in thickness (0.2 on either side) should have been added to the *spool* slop instead of the flap width slop, as the inner width of the spool (flap_width_slop) was not affected by the thickness parameter, while the outer width of the spool (spool_width_slop) *was*. This commit corrects that oversight.

This reverts commit a68fc988bc73c146c28ed1dc2c8e02c990d5ab93 (squashed as part of 7be69dbeb4fb7c1aa4b29027eb3e49a9b121c6a2).