### PR TITLE
fix a problem in the svg duplicate line culling

### DIFF
--- a/3d/scripts/requirements.txt
+++ b/3d/scripts/requirements.txt
@@ -1,1 +1,1 @@
-svg.path==2.2
+svg.path==4.0

--- a/3d/scripts/requirements.txt
+++ b/3d/scripts/requirements.txt
@@ -1,1 +1,1 @@
-svg.path==4.0
+svg.path==4.0.2


### PR DESCRIPTION
When culling duplicate lines in the generated svg files, if the path immediately preceding a `Close` element was pruned, the Close would end up drawing a line from the beginning of the deleted element, rather than the end. This is because even though the svg.path library adds a start and end point to a close instruction, the actual XML representation is just `Z`, with no coordinates, and it draws a line from the end of the previous line, to the location of the most recent `Move`. To fix this, this change replaces all `Close` elements with Lines instead.

Fixes #115