### PR TITLE
Go to next occurence of a repeated character

### DIFF
--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -190,7 +190,7 @@ inline int8_t FindFlapIndex(uint8_t character, uint8_t current_target_flap_index
           return i;
         }
     }
-		for (uint8_t i = 0; i < current_target_flap_index; i++) {
+    for (uint8_t i = 0; i < current_target_flap_index; i++) {
         if (character == flaps[i]) {
           return i;
         }

--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -184,8 +184,13 @@ void setup() {
 }
 
 
-inline int8_t FindFlapIndex(uint8_t character) {
-    for (int8_t i = 0; i < NUM_FLAPS; i++) {
+inline int8_t FindFlapIndex(uint8_t character, uint8_t current_target_flap_index) {
+    for (uint8_t i = current_target_flap_index; i < NUM_FLAPS; i++) {
+        if (character == flaps[i]) {
+          return i;
+        }
+    }
+		for (uint8_t i = 0; i < current_target_flap_index; i++) {
         if (character == flaps[i]) {
           return i;
         }
@@ -385,7 +390,7 @@ inline void run_iteration() {
               }
 #endif
               for (uint8_t i = 0; i < recv_count; i++) {
-                int8_t index = FindFlapIndex(recv_buffer[i]);
+                int8_t index = FindFlapIndex(recv_buffer[i], modules[i]->GetTargetFlapIndex());
                 if (index != -1) {
                   if (FORCE_FULL_ROTATION || index != modules[i]->GetTargetFlapIndex()) {
                     modules[i]->GoToFlapIndex(index);

--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -184,13 +184,13 @@ void setup() {
 }
 
 
-inline int8_t FindFlapIndex(uint8_t character, uint8_t current_target_flap_index) {
-    for (uint8_t i = current_target_flap_index; i < NUM_FLAPS; i++) {
+inline int8_t FindFlapIndex(uint8_t character, uint8_t current_flap_index) {
+    for (uint8_t i = current_flap_index; i < NUM_FLAPS; i++) {
         if (character == flaps[i]) {
           return i;
         }
     }
-    for (uint8_t i = 0; i < current_target_flap_index; i++) {
+    for (uint8_t i = 0; i < current_flap_index; i++) {
         if (character == flaps[i]) {
           return i;
         }
@@ -390,7 +390,7 @@ inline void run_iteration() {
               }
 #endif
               for (uint8_t i = 0; i < recv_count; i++) {
-                int8_t index = FindFlapIndex(recv_buffer[i], modules[i]->GetTargetFlapIndex());
+                int8_t index = FindFlapIndex(recv_buffer[i], modules[i]->GetCurrentFlapIndex());
                 if (index != -1) {
                   if (FORCE_FULL_ROTATION || index != modules[i]->GetTargetFlapIndex()) {
                     modules[i]->GoToFlapIndex(index);


### PR DESCRIPTION
**Intended goal:** enable repeat occurrences of the same character within `flaps[]`, for specific applications of splitflap displays (e.g. countdown clocks with more than 10 flaps).

In the use-case of a countdown clock (e.g. train arrival time countdown) the `flaps[]` definition might look something like this:

```
#define NUM_FLAPS (40) // Using 40 despite only 10 characters needed, to avoid significant hardware customization

const uint8_t flaps[NUM_FLAPS] = {
  '9', '8', '7', '6', '5', '4', '3', '2', '1', '0',
  '9', '8', '7', '6', '5', '4', '3', '2', '1', '0',
  '9', '8', '7', '6', '5', '4', '3', '2', '1', '0',
  '9', '8', '7', '6', '5', '4', '3', '2', '1', '0'
};
```

Currently, when moving from the character '0' to the character '9', the module would turn from index 9 all the way around to index 0, passing over the duplicate '9' characters at indices 10, 20, and 30.

To achieve the goal outlined above, this pull request alters the `FindFlapIndex` function in `Splitflap.ino`:

`FindFlapIndex` takes the current value of `target_flap_index` as a second argument, and loops through `flaps[]` starting at that index instead of starting at 0. This finds the NEXT occurrence of the desired character, rather than the FIRST occurrence, enabling repeated occurrences of the same character within `flaps[]`.

With this change, moving from the character '0' to the character '9' could be from index 9 to 10, or 19 to 20, or 29 to 30, or 39 to 0, minimizing the necessary rotation for splitflap implementations with repeated characters.


_(This is my first-ever contribution to an open source project so if I am going about this the wrong way, my apologies, and please let me know what I can do differently. Thanks!)_