### PR TITLE
Adjust kerf value

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -70,9 +70,9 @@ spool_horizontal_explosion = lookup(spool_explosion, [
 ]);
 
 
-// Ponoko kerf values are 0.2 mm for MDF and acrylic (all thicknesses)
+// Kerf adjustment value for 2D export, should be equal to the laser's kerf
 // Remember: it's better to underestimate (looser fit) than overestimate (no fit)
-kerf_width = 0.2 - 0.02;
+kerf_width = 0.1;
 
 // MDF, .120in nominal
 // https://www.ponoko.com/materials/mdf-fiberboard


### PR DESCRIPTION
This reduces the default kerf value from 0.18 (0.2 - 0.02) down to 0.1.

I used this value for my last 2 Ponoko orders with 3 mm acrylic and most dimensions are accurate to within +/- 0.06 mm. This has not been tested with Ponoko's MDF.