### PR TITLE
CAD: Tweak Spool Fitment Values

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -117,7 +117,7 @@ letter_color = color_invert(flap_color);  // inverse of the flap color, for cont
 flap_rendered_angle = 90;
 
 
-flap_width_slop = 0.15;  // amount of slop of the flap side to side between the 2 spools
+flap_width_slop = 0.25;  // amount of slop of the flap side to side between the 2 spools
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -121,7 +121,7 @@ flap_width_slop = 0.15;  // amount of slop of the flap side to side between the 
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 
-spool_tab_clearance = -0.02;  // for the tabs connecting the struts to the spool ends (interference fit)
+spool_tab_clearance = -0.08;  // for the tabs connecting the struts to the spool ends (interference fit)
 spool_retaining_clearance = 0.10;  // for the notches in the spool retaining wall
 spool_joint_clearance = 0.10;  // for the notched joints on the spool struts
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -117,7 +117,7 @@ letter_color = color_invert(flap_color);  // inverse of the flap color, for cont
 flap_rendered_angle = 90;
 
 
-flap_width_slop = 0.25;  // amount of slop of the flap side to side between the 2 spools
+flap_width_slop = 0.5;  // amount of slop of the flap side to side between the 2 spools
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -161,7 +161,9 @@ spool_strut_inner_length = spool_width - 3 * thickness;
 spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_strut_tab_outset+thickness/2) + (spool_strut_tab_width/2)*(spool_strut_tab_width/2));
 
 
-magnet_hole_radius = (4 - 0.1)/2;
+magnet_diameter = 4;
+magnet_hole_clearance = -0.1;  // interference fit
+magnet_hole_radius = (magnet_diameter + magnet_hole_clearance)/2;
 magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
 
 28byj48_chassis_height_slop = 1;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -121,7 +121,7 @@ flap_width_slop = 0.15;  // amount of slop of the flap side to side between the 
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 
-spool_tab_clearance = -0.08;  // for the tabs connecting the struts to the spool ends (interference fit)
+spool_tab_clearance = -0.06;  // for the tabs connecting the struts to the spool ends (interference fit)
 spool_retaining_clearance = 0.10;  // for the notches in the spool retaining wall
 spool_joint_clearance = 0.10;  // for the notched joints on the spool struts
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -162,7 +162,7 @@ spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_
 
 
 magnet_diameter = 4;
-magnet_hole_clearance = -0.1;  // interference fit
+magnet_hole_clearance = -0.09;  // interference fit
 magnet_hole_radius = (magnet_diameter + magnet_hole_clearance)/2;
 magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -162,7 +162,7 @@ spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_
 
 
 magnet_diameter = 4;
-magnet_hole_clearance = -0.09;  // interference fit
+magnet_hole_clearance = -0.07;  // interference fit
 magnet_hole_radius = (magnet_diameter + magnet_hole_clearance)/2;
 magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
 


### PR DESCRIPTION
On my latest order from Ponoko (3 mm acrylic) the spool struts are still loose and will need to be glued. This increases the interference a bit more (+ 0.04 mm) to hopefully reach a point where the struts will fit into the spool and hold there by friction alone.

Also increased is the flap width slop, in a reversion to the change from #114. On my order based around f4e7714 the flaps do *fit* and swing but it's tight - a little bit of misalignment with the spool end pieces or burrs on the parts will cause them to bind. And after gluing the end pieces in place not *perfectly* parallel (+/- 0.15 mm across ~48 mm diameter) that's exactly what has happened: some flaps on the spool do not 'flip' freely which breaks the whole display.

Originally I thought a slight increase to the flap slop would do the trick, but after giving it some more thought I think the slop decrease should be reverted in its entirety. It's one of the only critical dimensions in the design that can break the entire display if it's too tight, and there are too many factors that can influence the total clearance. Better to play things safe and keep this loose. If there is continued binding due to misalignment of flaps within the spool, the `spool_width_slop` value can be increased further.

I also parameterized and slightly reduced the magnet hole interference. On my displays the magnet press-fit is tight and I ended up cracking one of the spools.  The magnets seemed much happier and still held tight after some light sanding of the hole, so this value is being reduced ever-so-slightly.