### PR TITLE
Allow for programmatic offset values

### DIFF
--- a/arduino/splitflap/Splitflap/Splitflap.ino
+++ b/arduino/splitflap/Splitflap/Splitflap.ino
@@ -388,7 +388,7 @@ inline void run_iteration() {
                 int8_t index = FindFlapIndex(recv_buffer[i]);
                 if (index != -1) {
                   if (FORCE_FULL_ROTATION || index != modules[i]->GetTargetFlapIndex()) {
-                    modules[i]->GoToFlapIndex(index);
+                    modules[i]->GoToFlapIndex(index + flap_offset[i]);
                   }
                 }
                 Serial.write(recv_buffer[i]);

--- a/arduino/splitflap/Splitflap/config.h
+++ b/arduino/splitflap/Splitflap/config.h
@@ -9,8 +9,12 @@
 
 // 2) General Settings
 #ifndef NUM_MODULES
-#define NUM_MODULES (12)
+#define NUM_MODULES (4)
 #endif
+
+// Normally, this should be all 0's, but in case you need to adjust your offset,
+// you can do it programmatically instead of reseating every card
+const uint8_t flap_offset[NUM_MODULES] = { 0, 0, 0, 0 };
 
 // Whether to force a full rotation when the same letter is specified again
 #define FORCE_FULL_ROTATION true


### PR DESCRIPTION
I recently encountered an issue where I had everything honed in, but I was actually off by 1 flap.  Instead of removing and shifting everything manually, it was easier to just do it programatically.  My only concern is that it assumes the user has 4 modules (which is what the walkthrough has, so I figured it was a good assumption). 