### PR TITLE
Add more tolerance to cavity_top_allowance

### DIFF
--- a/3d/tools/flap_container.scad
+++ b/3d/tools/flap_container.scad
@@ -21,7 +21,7 @@ num_flaps = 40;
 containers_x = 1;
 containers_y = 1;
 
-flap_thickness_allowance = 1.1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
+flap_thickness_allowance = 1.1 - flap_thickness;  // fudged, so all flaps are considered 1.1 mm thick
 cavity_top_allowance = 2;  // extra case height above the flaps
 
 flap_clearance = 0.5;  // distance between the flap edges and the case walls

--- a/3d/tools/flap_container.scad
+++ b/3d/tools/flap_container.scad
@@ -21,8 +21,8 @@ num_flaps = 40;
 containers_x = 1;
 containers_y = 1;
 
-flap_thickness_allowance = 1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
-cavity_top_allowance = 5;  // extra case height above the flaps
+flap_thickness_allowance = 1.1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
+cavity_top_allowance = 2;  // extra case height above the flaps
 
 flap_clearance = 0.5;  // distance between the flap edges and the case walls
 wall_thickness = 3.5;  // thickness of the case walls around the flaps

--- a/3d/tools/flap_container.scad
+++ b/3d/tools/flap_container.scad
@@ -22,7 +22,7 @@ containers_x = 1;
 containers_y = 1;
 
 flap_thickness_allowance = 1 - flap_thickness;  // fudged, so all flaps are considered 1 mm thick
-cavity_top_allowance = 2;  // extra case height above the flaps
+cavity_top_allowance = 5;  // extra case height above the flaps
 
 flap_clearance = 0.5;  // distance between the flap edges and the case walls
 wall_thickness = 3.5;  // thickness of the case walls around the flaps


### PR DESCRIPTION
I think the default should add a bit more tolerance to the hight of the cavity.  I just printed it and it's about 3 cards too low for me.  Perhaps the vinyl added unexpected thickness.  I think 3mm extra should be good.