### PR TITLE
Module Connector Case

### DIFF
--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -225,6 +225,9 @@ connector_bracket_overlap = 4;
 connector_bracket_clearance = 0.10;
 connector_bracket_depth_clearance = 0.20;
 
+// 'get' functions to extract these values for when this file is 'used' and not 'included'
+function connector_bracket_length() = connector_bracket_length_outer;
+function connector_bracket_width() = connector_bracket_width;
 
 mounting_hole_inset = m4_button_head_diameter/2 + 2;
 
@@ -494,20 +497,24 @@ module front_tabs_negative() {
     }
 }
 
+module connector_bracket_2d() {
+    difference() {
+        square([connector_bracket_width, connector_bracket_length_outer]);
+        translate([connector_bracket_thickness, -eps]) {
+            square([connector_bracket_width - connector_bracket_thickness*2, connector_bracket_length_outer - connector_bracket_length_inner + eps]);
+        }
+        translate([connector_bracket_thickness - connector_bracket_clearance/2, -eps]) {
+            square([thickness + connector_bracket_clearance, connector_bracket_length_outer - connector_bracket_overlap + connector_bracket_depth_clearance + eps]);
+        }
+        translate([connector_bracket_width - connector_bracket_thickness - thickness - connector_bracket_clearance/2, -eps]) {
+            square([thickness + connector_bracket_clearance, connector_bracket_length_outer - connector_bracket_overlap + connector_bracket_depth_clearance + eps]);
+        }
+    }
+}
+
 module connector_bracket() {
     linear_extrude(height=thickness) {
-        difference() {
-            square([connector_bracket_width, connector_bracket_length_outer]);
-            translate([connector_bracket_thickness, -eps]) {
-                square([connector_bracket_width - connector_bracket_thickness*2, connector_bracket_length_outer - connector_bracket_length_inner + eps]);
-            }
-            translate([connector_bracket_thickness - connector_bracket_clearance/2, -eps]) {
-                square([thickness + connector_bracket_clearance, connector_bracket_length_outer - connector_bracket_overlap + connector_bracket_depth_clearance + eps]);
-            }
-            translate([connector_bracket_width - connector_bracket_thickness - thickness - connector_bracket_clearance/2, -eps]) {
-                square([thickness + connector_bracket_clearance, connector_bracket_length_outer - connector_bracket_overlap + connector_bracket_depth_clearance + eps]);
-            }
-        }
+        connector_bracket_2d();
     }
 }
 

--- a/3d/tools/connector_case.scad
+++ b/3d/tools/connector_case.scad
@@ -96,7 +96,6 @@ module connector_case(num_conn, num_cases, dual=false) {
         connector_case_row(num_conn, num_cases);
         if(dual) {
             translate([0, case_length_dual_offset, 0])
-            //translate([-20, -combined_offset, 0])
             mirror([0, 1, 0])
             connector_case_row(num_conn, num_cases);
         }

--- a/3d/tools/connector_case.scad
+++ b/3d/tools/connector_case.scad
@@ -1,0 +1,107 @@
+/*
+   Copyright 2021 Scott Bezek and the splitflap contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+include <../shapes.scad>
+use <../splitflap.scad>
+
+num_connectors = 4;  // number of connectors (vertically) per section
+thickness = 3.0;  // thickness of each connector (should be close to splitflap.scad panel thickness)
+cases_per_row = 2;  // number of cases per each row
+dual_rows = true;  // whether to put mirrored cases on the opposite side
+
+connector_clearance = 0.5;  // distance between the connector edges and the case walls
+wall_thickness = 3.5;  // thickness of the case walls around the connectors
+bottom_thickness = 5.0;  // thickness of the bottom of the case, below the connectors
+top_clearance = 0.4;  // clearance above the top of the connectors
+
+// auto-calculated constants
+combined_offset = connector_clearance + wall_thickness;  // total offset from base to outer edge
+side_wall_height = (thickness * num_connectors) + top_clearance;  // total height of the walls above the base
+case_width = connector_bracket_width() + (combined_offset * 2);  // width of the case (along X)
+case_width_per = case_width - wall_thickness;  // width of each case when in a group (combined wall thickness)
+case_length = connector_bracket_length() + (combined_offset * 2);  // length of the case (along Y)
+case_length_dual_offset = case_length + connector_bracket_length() - wall_thickness;  // Y offset for the 'dual' case row
+case_length_dual = case_length + case_length_dual_offset;  // total case length alokng Y with 'dual' option enabled
+
+
+module base_outline() {
+    offset(r=combined_offset, $fn=60) {
+        connector_bracket_2d();
+    }
+}
+
+module connector_case_cutout(num) {
+    width = 14 + connector_clearance;  // arbitrary
+    radius = 2.0;  // nicely rounded corners
+    height = (side_wall_height) + radius;  // total height of the tool (Z)
+    depth = connector_bracket_length();  // total depth of the tool (Y)
+
+    translate([0, depth, 0])
+    rotate([90, 0, 0])
+    linear_extrude(depth, convexity=2)
+    translate([connector_bracket_width()/2 - width/2, bottom_thickness, 0])
+    rounded_square([width, height], r=radius, $fn=30);
+}
+
+module connector_case_single(num) {
+    difference() {
+        // case body
+        union() {
+            // pocket
+            translate([0, 0, bottom_thickness]) {
+                linear_extrude(side_wall_height, convexity=10) {
+                    difference() {
+                        base_outline();
+                        offset(delta=connector_clearance) {
+                            connector_bracket_2d();
+                        }
+                    }
+                }
+            }
+
+            // bottom
+            linear_extrude(bottom_thickness, convexity=2) {
+                base_outline();
+            }
+        }
+        connector_case_cutout(num);
+    }
+}
+
+module connector_case_row(num_conn, num_cases) {
+    union() {
+        for ( i = [0 : num_cases - 1] ) {
+            translate([case_width_per * i, 0, 0])
+            connector_case_single(num_conn);
+        }
+    }
+    
+}
+
+module connector_case(num_conn, num_cases, dual=false) {
+    union() {
+        connector_case_row(num_conn, num_cases);
+        if(dual) {
+            translate([0, case_length_dual_offset, 0])
+            //translate([-20, -combined_offset, 0])
+            mirror([0, 1, 0])
+            connector_case_row(num_conn, num_cases);
+        }
+    }
+}
+
+
+connector_case(num_connectors, cases_per_row, dual_rows);


### PR DESCRIPTION
Since the connector pieces are a little fragile on there own and are not necessarily used for each module I designed a 3D printable case to store them. The design is modular and can be extended based on:

* The number of connectors per stack
* The number of stacks per row
* The number of rows per design (1 or 2)

Each stack of connectors can be retained with a rubber band. I've printed my own 3x2 version and it works great.

![sf-connector-case-cad](https://user-images.githubusercontent.com/24282108/109406647-c08cef00-7948-11eb-8a75-3f379d6bd9ea.png)
