### PR TITLE
Sensor PCB Tweaks

### DIFF
--- a/electronics/sensor.kicad_pcb
+++ b/electronics/sensor.kicad_pcb
@@ -234,7 +234,7 @@
     (arrow2a (pts (xy 24.572 18.476) (xy 25.698504 19.062421)))
     (arrow2b (pts (xy 24.572 18.476) (xy 25.698504 17.889579)))
   )
-  (gr_text "COMMIT: deadbeef\nDATE: YYYY-MM-DD" (at 35.494 31.684) (layer B.SilkS)
+  (gr_text "COMMIT: deadbeef\nDATE: YYYY-MM-DD" (at 35.494 30.25) (layer B.SilkS)
     (effects (font (size 1 0.9) (thickness 0.2)) (justify left mirror))
   )
   (dimension 8.636 (width 0.3) (layer Cmts.User)

--- a/electronics/sensor.kicad_pcb
+++ b/electronics/sensor.kicad_pcb
@@ -3,7 +3,7 @@
   (general
     (links 3)
     (no_connects 0)
-    (area 17.892999 15.098999 116.075001 68.075001)
+    (area 19.924999 19.924999 36.331001 36.331001)
     (thickness 1.6)
     (drawings 18)
     (tracks 6)
@@ -212,6 +212,7 @@
       (net 1 "Net-(P100-Pad1)"))
   )
 
+  (gr_line (start 20 36.256) (end 20 20) (angle 90) (layer Edge.Cuts) (width 0.15))
   (gr_text 5V (at 33.208 24.318 70) (layer F.SilkS)
     (effects (font (size 0.9 1) (thickness 0.15)) (justify right))
   )
@@ -296,7 +297,7 @@
     (arrow2a (pts (xy 24.572 38.034) (xy 25.698504 38.620421)))
     (arrow2b (pts (xy 24.572 38.034) (xy 25.698504 37.447579)))
   )
-  (gr_line (start 20 20) (end 116 20) (angle 90) (layer Edge.Cuts) (width 0.15))
+  (gr_line (start 20 20) (end 36.256 20) (angle 90) (layer Edge.Cuts) (width 0.15))
   (gr_text "Hall Effect" (at 31.43 21.27) (layer F.SilkS)
     (effects (font (size 1 1) (thickness 0.15)))
   )
@@ -309,9 +310,8 @@
   (gr_text GND (at 28.128 31.938 70) (layer F.SilkS)
     (effects (font (size 1.2 1.2) (thickness 0.25)) (justify left))
   )
-  (gr_line (start 36.256 15.174) (end 36.256 54.544) (angle 90) (layer Edge.Cuts) (width 0.15))
-  (gr_line (start 17.968 36.256) (end 73.848 36.256) (angle 90) (layer Edge.Cuts) (width 0.15))
-  (gr_line (start 20 68) (end 20 20) (angle 90) (layer Edge.Cuts) (width 0.15))
+  (gr_line (start 36.256 20) (end 36.256 36.256) (angle 90) (layer Edge.Cuts) (width 0.15))
+  (gr_line (start 20 36.256) (end 36.256 36.256) (angle 90) (layer Edge.Cuts) (width 0.15))
 
   (segment (start 33.208 33.208) (end 30.668 30.668) (width 0.5) (layer B.Cu) (net 1) (status 10))
   (segment (start 30.668 30.668) (end 30.668 23.302) (width 0.5) (layer B.Cu) (net 1) (tstamp 5B65CF4A) (status 20))


### PR DESCRIPTION
Fixes the sensor PCB `Edge.Cuts` layer continuity and moves the commit silkscreen off of the pads.

These commits were cherry-picked from PR #97