### PR TITLE
Fix firmware compilation for Uno

### DIFF
--- a/arduino/splitflap/Splitflap/src/spi_io_config.h
+++ b/arduino/splitflap/Splitflap/src/spi_io_config.h
@@ -145,8 +145,20 @@ inline void initialize_modules() {
   memset(sensor_buffer, 0, SENSOR_BUFFER_LENGTH);
 
   // Initialize SPI
+#ifdef IN_LATCH_PIN
+  pinMode(IN_LATCH_PIN, OUTPUT);
+  digitalWrite(IN_LATCH_PIN, HIGH);
+#endif
+
+#ifdef OUT_LATCH_PIN
+  pinMode(OUT_LATCH_PIN, OUTPUT);
+  digitalWrite(OUT_LATCH_PIN, LOW);
+#endif
+
+#ifdef LATCH_PIN
   pinMode(LATCH_PIN, OUTPUT);
   digitalWrite(LATCH_PIN, LOW);
+#endif
 
 #ifdef ESP32
 


### PR DESCRIPTION
These pin mode lines were removed as part of the chainlink driver PR (#132) and the consolidation to `LATCH_PIN` for the ESP32, which broke compilation for the "classic" driver on the Arduino Uno. Replacing these lines fixes the compilation error.