### PR TITLE
Enclosure Alignment Bar

### DIFF
--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -71,3 +71,14 @@ module arrow(size, aspect=[0.5, 0.3], center=false) {
             triangle(head);
     }
 }
+
+// positioned where origin is at the point to be rounded (first quadrant)
+module fillet_tool(r, overlap=0.01, $fn=$fn) {
+    tool_size = r + overlap;
+    translate([r, r, 0])
+    mirror([1, 1, 0])
+    difference() {
+        square([tool_size, tool_size]);
+        circle(r=r, $fn=$fn);
+    }
+}

--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -76,9 +76,9 @@ module arrow(size, aspect=[0.5, 0.3], center=false) {
 module fillet_tool(r, overlap=0.01, $fn=$fn) {
     tool_size = r + overlap;
     translate([r, r, 0])
-    mirror([1, 1, 0])
-    difference() {
-        square([tool_size, tool_size]);
-        circle(r=r, $fn=$fn);
-    }
+        mirror([1, 1, 0])
+            difference() {
+                square([tool_size, tool_size]);
+                circle(r=r, $fn=$fn);
+            }
 }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -630,10 +630,10 @@ module connector_bracket_side_holes() {
 
 module alignment_bar() {
     color(assembly_color1)
-    translate([enclosure_width - enclosure_horizontal_inset, -enclosure_length_right + front_forward_offset - alignment_bar_diameter/2, -enclosure_height_lower + alignment_bar_diameter/2])
-        rotate([0, -90, 0])
-            linear_extrude(height=enclosure_width * len(render_letters))
-                circle(r=alignment_bar_diameter/2, $fn=60);
+        translate([enclosure_width - enclosure_horizontal_inset, -enclosure_length_right + front_forward_offset - alignment_bar_diameter/2, -enclosure_height_lower + alignment_bar_diameter/2])
+            rotate([0, -90, 0])
+                linear_extrude(height=enclosure_width * len(render_letters))
+                    circle(r=alignment_bar_diameter/2, $fn=60);
 }
 
 module enclosure_left() {
@@ -703,7 +703,7 @@ module enclosure_left() {
                     // Back-side fillet
                     translate([0, -alignment_bar_cutout_width/2, 0])
                         mirror([0, 1, 0])
-                        fillet_tool(r=alignment_bar_fillet_radius, $fn=40);
+                            fillet_tool(r=alignment_bar_fillet_radius, $fn=40);
                 }
             }
         }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -697,8 +697,8 @@ module enclosure_left() {
                     square([alignment_bar_cutout_width, alignment_bar_cutout_width], center=true);
 
                     // Front-side fillet
-                    translate([0, alignment_bar_cutout_width/2, 0])
-                        fillet_tool(r=alignment_bar_fillet_radius, overlap=1, $fn=40);
+                    // translate([0, alignment_bar_cutout_width/2, 0])
+                    //     fillet_tool(r=alignment_bar_fillet_radius, overlap=1, $fn=40);
 
                     // Back-side fillet
                     translate([0, -alignment_bar_cutout_width/2, 0])

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -250,6 +250,13 @@ enclosure_left_zip_bottom_inset = 22.5;  // inset from bottom for the bottom zip
 
 enclosure_left_zip_top_inset = 22.5;  // inset from top for the top zip tie holes, edge to group center
 
+alignment_bar_diameter = 6.35;  // 1/4"
+alignment_bar_clearance = 0.25;
+alignment_bar_fillet_radius = 1.25;
+
+alignment_bar_cutout_width = alignment_bar_diameter + (2 * alignment_bar_clearance);
+alignment_bar_center = (enclosure_length - enclosure_length_right) - alignment_bar_cutout_width/2;
+
 
 echo(kerf_width=kerf_width);
 echo(enclosure_height=enclosure_height);
@@ -621,6 +628,14 @@ module connector_bracket_side_holes() {
     }
 }
 
+module alignment_bar() {
+    color(assembly_color1)
+    translate([enclosure_width - enclosure_horizontal_inset, -enclosure_length_right + front_forward_offset - alignment_bar_diameter/2, -enclosure_height_lower + alignment_bar_diameter/2])
+        rotate([0, -90, 0])
+            linear_extrude(height=enclosure_width * len(render_letters))
+                circle(r=alignment_bar_diameter/2, $fn=60);
+}
+
 module enclosure_left() {
     linear_extrude(height=thickness) {
         difference() {
@@ -672,6 +687,25 @@ module enclosure_left() {
             translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length - front_forward_offset])
                 rotate([0, 0, 90])  // cable channel facing 'up'
                     zip_tie_holes();
+
+            // Alignment bar cutout
+            translate([0, alignment_bar_center]) {
+                union() {
+                    // Cutout
+                    translate([alignment_bar_cutout_width/2, 0])
+                        circle(r=alignment_bar_cutout_width/2, $fn=40);
+                    square([alignment_bar_cutout_width, alignment_bar_cutout_width], center=true);
+
+                    // Front-side fillet
+                    translate([0, alignment_bar_cutout_width/2, 0])
+                        fillet_tool(r=alignment_bar_fillet_radius, overlap=1, $fn=40);
+
+                    // Back-side fillet
+                    translate([0, -alignment_bar_cutout_width/2, 0])
+                        mirror([0, 1, 0])
+                        fillet_tool(r=alignment_bar_fillet_radius, $fn=40);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Creates a hole in the left enclosure panel that is aligned with the back edge of the right side of the enclosure, to be used with a dowel rod or other round stock as an alignment aid for multiple modules.

The connector pieces are a bit of a pain to use since you have to remove the front panels and deal with the captive nuts that can be hidden underneath a full spool of flaps. This creates an alternate way to align the back edge of the modules without extending the length of the right panel and increasing the size and cost of the laser-cut design. In larger displays it also allows modules to be swapped out without having to undo any of the hardware.

Note that this does *not* prevent the module from twisting forwards about the alignment hole (along Z), and it would need either an accompanying strip on the front or a bracket attached to the right panel as well. For example, a pivoting latch attached to the mounting bolt or a thin tie around the bottom enclosure piece.

#### Photos:

![sf-alignment-bar-wide](https://user-images.githubusercontent.com/24282108/112714782-71d46580-8eb2-11eb-8f4b-c53d650c404f.png)

![sf-alignment-bar-close](https://user-images.githubusercontent.com/24282108/112714788-78fb7380-8eb2-11eb-8915-7d4b02b8563c.png)

![sf-alignment-bar-side](https://user-images.githubusercontent.com/24282108/112714786-76008300-8eb2-11eb-9b87-4b793c211f85.png)
