### PR TITLE
Additional Python Software Scripts

### DIFF
--- a/software/demo.py
+++ b/software/demo.py
@@ -1,13 +1,10 @@
 from __future__ import print_function
 
 import random
-import six
 import time
 
-import serial
-import serial.tools.list_ports
-
 from splitflap import splitflap
+from splitflap import ask_for_serial_port
 
 words = [
     'duck', 'goat', 'lion', 'bear', 'mole', 'crab',
@@ -28,24 +25,6 @@ def run():
             status = s.set_text(word)
             s.print_status(status)
             time.sleep(10)
-
-
-def ask_for_serial_port():
-    print('Available ports:')
-    ports = sorted(
-        filter(
-            lambda p: p.description != 'n/a',
-            serial.tools.list_ports.comports(),
-        ),
-        key=lambda p: p.device,
-    )
-    for i, port in enumerate(ports):
-        print('[{: 2}] {} - {}'.format(i, port.device, port.description))
-    print()
-    value = six.moves.input('Use which port? ')
-    port_index = int(value)
-    assert 0 <= port_index < len(ports)
-    return ports[port_index].device
 
 
 if __name__ == '__main__':

--- a/software/demo.py
+++ b/software/demo.py
@@ -26,7 +26,7 @@ def run():
             word = random.choice(words)
             print('Going to {}'.format(word))
             status = s.set_text(word)
-            print_status(status)
+            s.print_status(status)
             time.sleep(10)
 
 
@@ -46,20 +46,6 @@ def ask_for_serial_port():
     port_index = int(value)
     assert 0 <= port_index < len(ports)
     return ports[port_index].device
-
-
-def print_status(status):
-    for module in status:
-        state = ''
-        if module['state'] == 'panic':
-            state = '!!!!'
-        elif module['state'] == 'look_for_home':
-            state = '...'
-        elif module['state'] == 'sensor_error':
-            state = '????'
-        elif module['state'] == 'normal':
-            state = module['flap']
-        print('{:4}  {: 4} {: 4}'.format(state, module['count_missed_home'], module['count_unexpected_home']))
 
 
 if __name__ == '__main__':

--- a/software/flap_test.py
+++ b/software/flap_test.py
@@ -1,0 +1,25 @@
+from time import sleep
+
+from splitflap import splitflap
+from splitflap import ask_for_serial_port
+
+
+def run():
+    port = ask_for_serial_port()
+
+    print('Starting...')
+    with splitflap(port) as s:
+        characters = s.get_character_list()
+
+        while(True):
+            for i, c in enumerate(characters):
+                string = c * s.get_num_modules()
+                print('Going to index {} (\'{}\')'.format(i, c))
+                status = s.set_text(string)
+                s.print_status(status)
+                sleep(1)
+            sleep(10)
+
+
+if __name__ == '__main__':
+    run()

--- a/software/flap_test.py
+++ b/software/flap_test.py
@@ -10,15 +10,31 @@ def run():
     print('Starting...')
     with splitflap(port) as s:
         characters = s.get_character_list()
+        num_flaps = len(characters)
 
+        # make sure all modules are home'd before we continue
         while(True):
-            for i, c in enumerate(characters):
-                string = c * s.get_num_modules()
-                print('Going to index {} (\'{}\')'.format(i, c))
-                status = s.set_text(string)
-                s.print_status(status)
-                sleep(1)
-            sleep(10)
+            at_home = True
+            for module in s.get_status():
+                at_home &= (module["flap"] == characters[0])
+            if not at_home:
+                s.recalibrate_all()
+            else:
+                break
+
+        index = 1  # we're at home (#0), start at flap #1
+
+        # loop through all flaps on every module
+        while(True):
+            char = characters[index]
+            string = char * s.get_num_modules()
+            print('Going to index {} (\'{}\')'.format(index, char))
+            status = s.set_text(string)
+            s.print_status(status)
+            if index == 0:
+                break  # we're back home
+            index = (index + 1) % num_flaps
+            sleep(1)
 
 
 if __name__ == '__main__':

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -100,6 +100,9 @@ class Splitflap(object):
     def get_status(self):
         return self.last_status
 
+    def get_num_modules(self):
+        return self.num_modules
+
     def print_status(self, status=None):
         if(status is None):
             status = self.last_status

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -97,6 +97,22 @@ class Splitflap(object):
     def get_status(self):
         return self.last_status
 
+    def print_status(self, status=None):
+        if(status is None):
+            status = self.last_status
+
+        for module in status:
+            state = ''
+            if module['state'] == 'panic':
+                state = '!!!!'
+            elif module['state'] == 'look_for_home':
+                state = '...'
+            elif module['state'] == 'sensor_error':
+                state = '????'
+            elif module['state'] == 'normal':
+                state = module['flap']
+            print('{:4}  {: 4} {: 4}'.format(state, module['count_missed_home'], module['count_unexpected_home']))
+
 
 @contextmanager
 def splitflap(serial_port):

--- a/software/splitflap.py
+++ b/software/splitflap.py
@@ -2,6 +2,9 @@ import json
 from contextlib import contextmanager
 
 import serial
+import serial.tools.list_ports
+
+import six
 
 _ALPHABET = {
     ' ',
@@ -120,3 +123,21 @@ def splitflap(serial_port):
         s = Splitflap(ser)
         s._loop_for_status()
         yield s
+
+
+def ask_for_serial_port():
+    print('Available ports:')
+    ports = sorted(
+        filter(
+            lambda p: p.description != 'n/a',
+            serial.tools.list_ports.comports(),
+        ),
+        key=lambda p: p.device,
+    )
+    for i, port in enumerate(ports):
+        print('[{: 2}] {} - {}'.format(i, port.device, port.description))
+    print()
+    value = six.moves.input('Use which port? ')
+    port_index = int(value)
+    assert 0 <= port_index < len(ports)
+    return ports[port_index].device

--- a/software/terminal.py
+++ b/software/terminal.py
@@ -1,0 +1,37 @@
+from splitflap import splitflap
+from splitflap import ask_for_serial_port
+
+
+def filter_string(string, sf):
+    str_list = list(string)  # use list instead of string so it's mutable
+
+    for i, c in enumerate(str_list):
+        new_char = ' '  # replace with space if not in list
+        if sf.in_character_list(c):
+            continue  # in list, continue
+        elif c.isalpha():
+            alt_char = c.lower() if c.isupper() else c.upper()  # check for upper/lowercase equivalent
+            if sf.in_character_list(alt_char):
+                new_char = alt_char
+
+        str_list[i] = new_char  # replace character in list
+
+    return ''.join(str_list)
+
+
+def run():
+    port = ask_for_serial_port()
+
+    print('Starting...')
+    with splitflap(port) as s:
+        while True:
+            string = input("Enter text: ")
+            string = filter_string(string, s)  # filter characters to displayable ones
+            string = string.ljust(s.get_num_modules(), ' ')  # pad to the right with spaces
+            print('Going to {}'.format(string))
+            status = s.set_text(string)
+            s.print_status(status)
+
+
+if __name__ == '__main__':
+    run()

--- a/software/terminal.py
+++ b/software/terminal.py
@@ -26,6 +26,8 @@ def run():
     with splitflap(port) as s:
         while True:
             string = input("Enter text: ")
+            if string == "exit" or string == "quit" or string == "q":
+                break
             string = filter_string(string, s)  # filter characters to displayable ones
             string = string.ljust(s.get_num_modules(), ' ')  # pad to the right with spaces
             print('Going to {}'.format(string))


### PR DESCRIPTION
Adds two new Python software scripts:
* **flap_test.py**, which homes the display and then runs through all flaps one at a time (1s between).
* **terminal.py**, which passes strings from input prompts to the display, checking for lower/uppercase alternatives and padding with spaces.

This also moves the `print_status` and `ask_for_serial_port` functions to the `splitflap` module to share them between scripts, and adds a `get_num_modules` function.