### PR TITLE
Add corner relief to punch jig

### DIFF
--- a/3d/tools/punch_jig.scad
+++ b/3d/tools/punch_jig.scad
@@ -31,23 +31,35 @@ slot_width = 15;
 eps = 0.1;
 
 jig_length = flap_width + slot_inset_depth;
+flap_void_width = flap_width + slot_depth + print_tolerance*2 + eps;
+flap_void_height = jig_thickness + print_tolerance + flap_height - (punch_width - slot_width)/2 + flap_pin_width + print_tolerance + eps;
+flap_corner_relief = 0.05; // as multiplier of flap void
 
 union() {
     linear_extrude(height=punch_gap_height - print_tolerance*2) {
         difference() {
             square([jig_length, jig_thickness*2 + print_tolerance*2 + flap_height]);
             translate([slot_inset_depth - print_tolerance*2, jig_thickness + print_tolerance + (punch_width - slot_width)/2 - flap_pin_width - print_tolerance]) {
-                square([flap_width + slot_depth + print_tolerance*2 + eps, jig_thickness + print_tolerance + flap_height - (punch_width - slot_width)/2 + flap_pin_width + print_tolerance + eps]);
+                union() {
+                    square([flap_void_width, flap_void_height]);
+                    // create relief for flap corner
+                    translate([-1,-1]) {
+                        square([flap_void_width*flap_corner_relief, flap_void_width*flap_corner_relief]);
+                    }
+                }
+
             }
         }
     }
 
+    // create support for right side of punch
     translate([0, 0, punch_gap_height - print_tolerance*2]) {
         linear_extrude(height=punch_lower_height, scale=[1, (jig_thickness + clamp_inset)/jig_thickness]) {
             square([jig_length, jig_thickness]);
         }
     }
 
+    // create support for left side of punch
     translate([0, jig_thickness*2 + print_tolerance*2 + punch_width, punch_gap_height - print_tolerance*2]) {
         linear_extrude(height=punch_lower_height, scale=[1, (jig_thickness + clamp_inset)/jig_thickness]) {
             translate([0, -jig_thickness]) {


### PR DESCRIPTION
In order to cater for flaps that aren't cut precisely on the corners and for printers that create a small radius, cut out the corner of the punch jig to allow flaps to sit tightly into the corner.