### PR TITLE
rev_info.py: print helpful message if git command fails

### DIFF
--- a/util/rev_info.py
+++ b/util/rev_info.py
@@ -2,12 +2,15 @@ import datetime
 import subprocess
 
 def git_short_rev():
-    return subprocess.check_output([
-        'git',
-        'rev-parse',
-        '--short',
-        'HEAD',
-    ]).decode('utf-8').strip()
+    try:
+        return subprocess.check_output([
+            'git',
+            'rev-parse',
+            '--short',
+            'HEAD',
+        ]).decode('utf-8').strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "notfound"
 
 def current_date():
     return datetime.date.today().strftime('%Y-%m-%d')

--- a/util/rev_info.py
+++ b/util/rev_info.py
@@ -2,12 +2,15 @@ import datetime
 import subprocess
 
 def git_short_rev():
-    return subprocess.check_output([
-        'git',
-        'rev-parse',
-        '--short',
-        'HEAD',
-    ]).decode('utf-8').strip()
+    try:
+        return subprocess.check_output([
+            'git',
+            'rev-parse',
+            '--short',
+            'HEAD',
+        ]).decode('utf-8').strip()
+    except Exception:
+        raise RuntimeError("Could not read git revision. Make sure you have git installed and you're working off of a git clone of the repository.")
 
 def current_date():
     return datetime.date.today().strftime('%Y-%m-%d')

--- a/util/rev_info.py
+++ b/util/rev_info.py
@@ -2,16 +2,12 @@ import datetime
 import subprocess
 
 def git_short_rev():
-    try:
-        return subprocess.check_output([
-            'git',
-            'rev-parse',
-            '--short',
-            'HEAD',
-        ]).decode('utf-8').strip()
-    except Exception as e:
-        print("Exception: " + type(e).__name__ + " while trying to find git revision")
-        return "notfound"
+    return subprocess.check_output([
+        'git',
+        'rev-parse',
+        '--short',
+        'HEAD',
+    ]).decode('utf-8').strip()
 
 def current_date():
     return datetime.date.today().strftime('%Y-%m-%d')

--- a/util/rev_info.py
+++ b/util/rev_info.py
@@ -10,7 +10,7 @@ def git_short_rev():
             'HEAD',
         ]).decode('utf-8').strip()
     except Exception:
-        raise RuntimeError("Could not read git revision. Make sure you have git installed and you're working off of a git clone of the repository.")
+        raise RuntimeError("Could not read git revision. Make sure you have git installed and you're working with a git clone of the repository.")
 
 def current_date():
     return datetime.date.today().strftime('%Y-%m-%d')

--- a/util/rev_info.py
+++ b/util/rev_info.py
@@ -9,7 +9,8 @@ def git_short_rev():
             '--short',
             'HEAD',
         ]).decode('utf-8').strip()
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except Exception as e:
+        print("Exception: " + type(e).__name__ + " while trying to find git revision")
         return "notfound"
 
 def current_date():


### PR DESCRIPTION
Will return "notfound" as the commit hash in cases where git is unavailable or the invoked script is not part of a git repository. This allows export scripts to work if the user downloads the repo without git cloning it.