### PR TITLE
Allow generation for double-sided flaps

### DIFF
--- a/3d/scripts/generate_fonts.py
+++ b/3d/scripts/generate_fonts.py
@@ -46,9 +46,14 @@ if __name__ == '__main__':
     parser.add_argument('-x', '--offset-x', type=float, help='Character offset from center, X-axis')
     parser.add_argument('-y', '--offset-y', type=float, help='Character offset from center, Y-axis')
 
+    parser.add_argument('--start-row', type=int, help="The starting row to render, 0-indexed")
+    parser.add_argument('--row-count', type=int, help="Number of rows to render")
+
+    parser.add_argument('--double-sided', action='store_true', help='Generate double sided print')
     parser.add_argument('--ncolumns', type=int, help='Number of columns / characters per row')
     parser.add_argument('--no-comp', action='store_true', default=False, help='Don\'t compensate for the gap between top and bottom flaps')
 
+    parser.add_argument('--bleed', action='store_true', help='Bleed the letters')
     parser.add_argument('--kerf', type=float, help='Override kerf_width value')
     parser.add_argument('--fill', action='store_true', help='Fill the text solid (disables optimization)')
     parser.add_argument('--skip-optimize', action='store_true', help='Don\'t remove redundant/overlapping cut lines')
@@ -78,26 +83,43 @@ if __name__ == '__main__':
     if args.offset_y is not None:
         extra_variables['letter_offset_y'] = args.offset_y
 
+    if args.start_row is not None:
+        extra_variables['start_row'] = args.start_row
+    if args.row_count is not None:
+        extra_variables['row_count'] = args.row_count
+
     if args.ncolumns is not None:
         extra_variables['num_columns'] = args.ncolumns
 
     if args.kerf is not None:
         extra_variables['kerf_width'] = args.kerf
-    if args.fill is True:
+    if args.fill:
         extra_variables['render_fill'] = True
         args.skip_optimize = True
+    if args.bleed:
+        extra_variables['bleed'] = True
 
-    renderer = Renderer(os.path.join(source_parts_dir, 'font_generator.scad'), output_directory, extra_variables)
-    renderer.clean()
-    svg_output = renderer.render_svgs(panelize_quantity = 1)
+    def render():
+        renderer = Renderer(os.path.join(source_parts_dir, 'font_generator.scad'), output_directory, extra_variables)
+        renderer.clean()
+        svg_output = renderer.render_svgs(panelize_quantity = 1)
 
-    processor = SvgProcessor(svg_output)
+        processor = SvgProcessor(svg_output)
 
-    redundant_lines, merged_lines = None, None
-    if not args.skip_optimize:
-        logging.info('Removing redundant lines')
-        redundant_lines, merged_lines = processor.remove_redundant_lines()
+        redundant_lines, merged_lines = None, None
+        if not args.skip_optimize:
+            logging.info('Removing redundant lines')
+            redundant_lines, merged_lines = processor.remove_redundant_lines()
 
-    processor.write(svg_output)
+        processor.write(svg_output)
+        logging.info('\n\n\nDone rendering to SVG: ' + svg_output)
 
-    logging.info('\n\n\nDone rendering to SVG: ' + svg_output)
+    if args.double_sided:
+        output_directory = os.path.join(source_parts_dir, 'build', 'fonts', 'front')
+        extra_variables['side'] = 1
+        render()
+        output_directory = os.path.join(source_parts_dir, 'build', 'fonts', 'back')
+        extra_variables['side'] = 2
+        render()
+    else:
+        render()

--- a/3d/scripts/generate_fonts.py
+++ b/3d/scripts/generate_fonts.py
@@ -46,8 +46,8 @@ if __name__ == '__main__':
     parser.add_argument('-x', '--offset-x', type=float, help='Character offset from center, X-axis')
     parser.add_argument('-y', '--offset-y', type=float, help='Character offset from center, Y-axis')
 
-    parser.add_argument('--start-row', type=int, help="The starting row to render, 0-indexed")
-    parser.add_argument('--row-count', type=int, help="Number of rows to render")
+    parser.add_argument('--start-row', type=int, help='The starting row to render, 0-indexed')
+    parser.add_argument('--row-count', type=int, help='Number of rows to render')
 
     parser.add_argument('--double-sided', action='store_true', help='Generate double sided print')
     parser.add_argument('--ncolumns', type=int, help='Number of columns / characters per row')

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -462,13 +462,21 @@ module draw_letter(letter) {
                 text(text=letter, size=flap_height * letter_height * 2, font=letter_font, halign="center");
 }
 
-module flap_letter(letter, half = 0) {
+module flap_letter(letter, half = 0, bleed = false) {
     color(letter_color)
     translate([0, 0, flap_thickness/2 + eps])
     linear_extrude(height=0.1, center=true) {
         if (half != 0) {  // trimming to top (1) or bottom (2)
             intersection() {
-                flap_2d();  // limit to bounds of flap
+                if (bleed) {
+                    minkowski()
+                    {
+                        flap_2d();
+                        circle(d=flap_gap);
+                    }
+                } else {
+                    flap_2d();  // limit to bounds of flap
+                }
                 translate([flap_width/2, -flap_pin_width/2, 0]) {
                     rotation = (half == 2) ? -180 : 0;  // flip upside-down for bottom
                     gap_comp = (letter_gap_comp == true) ? -flap_gap/2 : 0;


### PR DESCRIPTION
This allows the generation of double-sided flaps, ideal for laser cutters/printers.

This PR adds the following arguments to `generate_fonts.py`:

* `--double-sided`: Generate a double-sided version of the flaps, for double-sided printing and laser-cutting.
* `--bleed`: Bleed the letters. This allows some margin for error during double-sided printing and laser-cutting.
* `--start-row`: The row to start rendering. Combined with the `--row-count`, this allows pagination of the flaps.
* `--row-count`: How many rows to render.

Demo:

https://user-images.githubusercontent.com/7296537/116824424-20c22c00-ab58-11eb-9018-0786b54eec7b.mov

Sample of Generated Flaps:

![1a](https://user-images.githubusercontent.com/7296537/116824476-75fe3d80-ab58-11eb-99e6-e58b4dceacda.png)

![1b](https://user-images.githubusercontent.com/7296537/116824477-7696d400-ab58-11eb-82da-b5ed076d62e5.png)


