### PR TITLE
Integrate PlatformIO to CI Workflow

### DIFF
--- a/.github/workflows/pio.yml
+++ b/.github/workflows/pio.yml
@@ -1,0 +1,44 @@
+name: PlatformIO CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pio-build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+
+    - name: Build Firmware
+      run: |
+        pio run -d ./arduino/splitflap \
+          -e uno-shift-register \
+          -e uno-direct \
+          -e mega-direct \
+          -e esp32 \
+          -e chainlink


### PR DESCRIPTION
Followed the instructions at https://docs.platformio.org/en/latest/integration/ci/github-actions.html to add the GitHub Action.
Since I was unsure which platformio environments are active, I included all of them.

Should close #141.