### PR TITLE
Add jig for testing motor+sensor

### DIFF
--- a/3d/28byj-48.scad
+++ b/3d/28byj-48.scad
@@ -34,6 +34,15 @@
 28byj48_backpack_extent = 18; // seen values from 17-18
 28byj48_backpack_height = 16;
 
+// Exports for use in other files:
+function 28byj48_mount_bracket_height() = 28byj48_mount_bracket_height;
+function 28byj48_shaft_radius() = 28byj48_shaft_radius;
+function 28byj48_mount_center_offset() = 28byj48_mount_center_offset;
+function 28byj48_chassis_radius() = 28byj48_chassis_radius;
+function 28byj48_shaft_offset() = 28byj48_shaft_offset;
+function 28byj48_chassis_height() = 28byj48_chassis_height;
+function 28byj48_backpack_extent() = 28byj48_backpack_extent;
+
 // Basic 28BYJ-48 model based on various dimensioned drawings.
 // Origin is centered on the shaft, on the front face of the motor, with the shaft in the +z direction
 module Stepper28BYJ48() {
@@ -90,7 +99,7 @@ module Stepper28BYJ48() {
             translate([0, 0, -28byj48_chassis_height]) {
                 cylinder(r=28byj48_chassis_radius, h=28byj48_chassis_height);
             }
-            translate([0, 0, -28byj48_mount_bracket_height]) {
+            translate([0, 0, -28byj48_mount_bracket_height - eps]) {
                 mounting_holes();
             }
             translate([0, 28byj48_shaft_offset, -eps]) {
@@ -117,3 +126,6 @@ module Stepper28BYJ48() {
         }
     }
 }
+
+// Example usage:
+Stepper28BYJ48();

--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -138,8 +138,8 @@ module pcb(pcb_to_spool, render_jig=false) {
 }
 
 // 2D cutouts needed to mount the PCB module, origin at the center of the mounting hole
-module pcb_cutouts() {
-    hull_slide() {
+module pcb_cutouts(adjustment_range=pcb_adjustment_range) {
+    hull_slide(delta=adjustment_range) {
         // Bolt slot
         hull() {
             circle(r=m4_hole_diameter/2, $fn=30);
@@ -160,13 +160,13 @@ module pcb_cutouts() {
     }
 }
 
-module hull_slide() {
+module hull_slide(delta) {
     for (i = [0:$children - 1]) {
         hull() {
-            translate([-pcb_adjustment_range, 0]) {
+            translate([-delta, 0]) {
                 children(i);
             }
-            translate([pcb_adjustment_range, 0]) {
+            translate([delta, 0]) {
                 children(i);
             }
         }
@@ -206,3 +206,6 @@ module sensor_jig(pcb_to_spool) {
         }
     }
 }
+
+// Example usage:
+pcb(10);

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use<28byj-48.scad>;
 use<assert.scad>;
 use<label.scad>;
 use<pcb.scad>;
@@ -23,7 +24,6 @@ use<rough7380.scad>;
 use<spool.scad>;
 use<shapes.scad>;
 
-include<28byj-48.scad>;
 include<flap_dimensions.scad>;
 include<flap_fonts.scad>;
 include<m4_dimensions.scad>;
@@ -77,6 +77,7 @@ kerf_width = 0.2 - 0.02;
 // MDF, .120in nominal
 // https://www.ponoko.com/materials/mdf-fiberboard
 thickness = 3.0;
+function get_thickness() = thickness;
 
 etch_depth = 0.1;  // for render
 eps=.01;
@@ -162,9 +163,11 @@ spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_
 
 
 magnet_diameter = 4;
+function get_magnet_diameter() = magnet_diameter;
 magnet_hole_clearance = -0.07;  // interference fit
 magnet_hole_radius = (magnet_diameter + magnet_hole_clearance)/2;
 magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
+function get_magnet_hole_offset() = magnet_hole_offset;
 
 // Clearance between the motor chassis and the outside right wall of the previous module
 28byj48_chassis_height_clearance = 1.4;
@@ -174,10 +177,10 @@ motor_slop_radius = 3;
 
 
 // Width measured from the outside of the walls
-enclosure_wall_to_wall_width = thickness + spool_width_slop/2 + spool_width_clearance + spool_width_slop/2 + max(28byj48_mount_bracket_height + m4_button_head_length, 4 + 28byj48_mount_bracket_height - spool_width_slop/2) + thickness;
+enclosure_wall_to_wall_width = thickness + spool_width_slop/2 + spool_width_clearance + spool_width_slop/2 + max(28byj48_mount_bracket_height() + m4_button_head_length, 4 + 28byj48_mount_bracket_height() - spool_width_slop/2) + thickness;
 
 // Width of the front panel
-enclosure_width = enclosure_wall_to_wall_width + 28byj48_chassis_height + 28byj48_chassis_height_clearance - thickness - 28byj48_mount_bracket_height;
+enclosure_width = enclosure_wall_to_wall_width + 28byj48_chassis_height() + 28byj48_chassis_height_clearance - thickness - 28byj48_mount_bracket_height();
 enclosure_horizontal_inset = (enclosure_width - enclosure_wall_to_wall_width)/2;
 front_window_upper_base = (flap_height - flap_pin_width/2);
 front_window_overhang = 3;
@@ -194,11 +197,11 @@ enclosure_height = enclosure_height_upper + enclosure_height_lower;
 
 enclosure_horizontal_rear_margin = thickness; // minumum distance between the farthest feature and the rear
 
-enclosure_length = front_forward_offset + 28byj48_mount_center_offset + m4_hole_diameter/2 + enclosure_horizontal_rear_margin;
+enclosure_length = front_forward_offset + 28byj48_mount_center_offset() + m4_hole_diameter/2 + enclosure_horizontal_rear_margin;
 
 // distance from the outside spool face to the inside of the left enclosure
 pcb_to_spool = enclosure_wall_to_wall_width - front_window_width - thickness + spool_width_slop/2;
-
+function get_pcb_to_spool() = pcb_to_spool;  // for exposing this value when this file is 'used' and not 'included' in other files
 
 // Enclosure tabs: front/back
 enclosure_tab_clearance = 0.10;
@@ -216,7 +219,7 @@ backstop_bolt_vertical_offset = - (exclusion_radius + outer_exclusion_radius)/2;
 backstop_bolt_forward_range = 14;
 
 motor_mount_hole_radius = m4_hole_diameter/2;
-motor_backpack_extent = 28byj48_backpack_extent + 2; // Add 2mm to make sure there's room for the wires
+motor_backpack_extent = 28byj48_backpack_extent() + 2; // Add 2mm to make sure there's room for the wires
 motor_hole_slop = 1;
 motor_window_radius = 5;
 
@@ -497,10 +500,10 @@ module flap_letter(letter, half = 0, bleed = false) {
 module motor_shaft() {
     union() {
         intersection() {
-            circle(r=28byj48_shaft_radius-motor_shaft_under_radius, $fn=50);
-            square([28byj48_shaft_radius*2, 3], center=true);
+            circle(r=28byj48_shaft_radius()-motor_shaft_under_radius, $fn=50);
+            square([28byj48_shaft_radius()*2, 3], center=true);
         }
-        square([28byj48_shaft_radius/3, 28byj48_shaft_radius*4], center=true);
+        square([28byj48_shaft_radius()/3, 28byj48_shaft_radius()*4], center=true);
     }
 }
 
@@ -584,18 +587,17 @@ module enclosure_front_etch() {
 
 // holes for 28byj-48 motor, centered around motor shaft
 module motor_mount() {
-    circle(r=28byj48_shaft_radius+motor_slop_radius, $fn=30);
-    translate([-28byj48_mount_center_offset, -8]) {
+    translate([-28byj48_mount_center_offset(), -28byj48_shaft_offset()]) {
         circle(r=motor_mount_hole_radius, $fn=30);
     }
-    translate([28byj48_mount_center_offset, -8]) {
+    translate([28byj48_mount_center_offset(), -28byj48_shaft_offset()]) {
         circle(r=motor_mount_hole_radius, $fn=30);
     }
 
     hull() {
-        x = -28byj48_chassis_radius - motor_hole_slop/2 + motor_window_radius;
-        y = [-28byj48_shaft_offset - motor_backpack_extent - motor_hole_slop/2 + motor_window_radius,
-            -28byj48_shaft_offset + 28byj48_chassis_radius + motor_hole_slop/2 - motor_window_radius];
+        x = -28byj48_chassis_radius() - motor_hole_slop/2 + motor_window_radius;
+        y = [-28byj48_shaft_offset() - motor_backpack_extent - motor_hole_slop/2 + motor_window_radius,
+            -28byj48_shaft_offset() + 28byj48_chassis_radius() + motor_hole_slop/2 - motor_window_radius];
 
         translate([ x, y[0], 0]) circle(r=motor_window_radius, $fn=40);
         translate([-x, y[1], 0]) circle(r=motor_window_radius, $fn=40);
@@ -728,7 +730,7 @@ module enclosure_left_etch() {
 
 module shaft_centered_motor_hole() {
     margin = 5;
-    width = 28byj48_mount_center_offset*2 + 3.5*2 + margin*2;
+    width = 28byj48_mount_center_offset()*2 + 3.5*2 + margin*2;
     length = 18 + 14 + margin*2;
 
     translate([-width/2, -(margin + 18 + 8)])
@@ -1192,25 +1194,25 @@ module split_flap_3d(letter, include_connector) {
     }
 
     if (render_motor) {
-        translate([enclosure_wall_to_wall_width - thickness - 28byj48_mount_bracket_height, 0, 0]) {
+        translate([enclosure_wall_to_wall_width - thickness - 28byj48_mount_bracket_height(), 0, 0]) {
 
             rotate([-90, 0, 0]) {
 
                 rotate([0, -90, 0]) {
                     Stepper28BYJ48();
                 }
-                translate([0, -28byj48_shaft_offset, 0]) {
-                    translate([0, 0, -28byj48_mount_center_offset]) {
+                translate([0, -28byj48_shaft_offset(), 0]) {
+                    translate([0, 0, -28byj48_mount_center_offset()]) {
                         rotate([0, 90, 0]) {
                             rotate([0, 0, 90]) {
-                                standard_m4_bolt(nut_distance=thickness+28byj48_mount_bracket_height);
+                                standard_m4_bolt(nut_distance=thickness+28byj48_mount_bracket_height());
                             }
                         }
                     }
-                    translate([0, 0, 28byj48_mount_center_offset]) {
+                    translate([0, 0, 28byj48_mount_center_offset()]) {
                         rotate([0, 90, 0]) {
                             rotate([0, 0, 90]) {
-                                standard_m4_bolt(nut_distance=thickness+28byj48_mount_bracket_height);
+                                standard_m4_bolt(nut_distance=thickness+28byj48_mount_bracket_height());
                             }
                         }
                     }
@@ -1326,11 +1328,11 @@ if (render_3d) {
             }
 
             // Spool retaining wall in motor window
-            translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
+            translate([enclosure_height_lower + 28byj48_shaft_offset() - 28byj48_chassis_radius() + (28byj48_chassis_radius() + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius() - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
                 spool_retaining_wall(m4_bolt_hole=true);
 
             // Sensor soldering jig
-            translate([enclosure_height_lower + 28byj48_shaft_offset - 28byj48_chassis_radius + (28byj48_chassis_radius + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius + motor_hole_slop/2 - kerf_width])
+            translate([enclosure_height_lower + 28byj48_shaft_offset() - 28byj48_chassis_radius() + (28byj48_chassis_radius() + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius() + motor_hole_slop/2 - kerf_width])
                 rotate([0, 0, 180])
                     sensor_jig(pcb_to_spool);
         }

--- a/3d/tools/motor_test_jig.scad
+++ b/3d/tools/motor_test_jig.scad
@@ -1,0 +1,172 @@
+use<../splitflap.scad>;
+use<../pcb.scad>;
+use<../28byj-48.scad>;
+
+include<../m4_dimensions.scad>;
+
+$fn = 30;
+
+eps = 0.01;
+
+
+export = true;
+
+
+module dim(enabled=true) {
+    if (enabled) {   
+        %color([0,0,0, .2]) {
+            children();
+        }
+    } else {
+        children();
+    }
+}
+
+// holes for 28byj-48 motor, centered around motor shaft
+module motor_mount_holes() {
+    translate([-28byj48_mount_center_offset(), -28byj48_shaft_offset()]) {
+        circle(r=motor_mount_hole_radius, $fn=30);
+    }
+    translate([28byj48_mount_center_offset(), -28byj48_shaft_offset()]) {
+        circle(r=motor_mount_hole_radius, $fn=30);
+    }
+}
+
+module sector(radius, angles, fn = 24) {
+    r = radius / cos(180 / fn);
+    step = -360 / fn;
+
+    points = concat([[0, 0]],
+        [for(a = [angles[0] : step : angles[1] - 360]) 
+            [r * cos(a), r * sin(a)]
+        ],
+        [[r * cos(angles[1]), r * sin(angles[1])]]
+    );
+
+    difference() {
+        circle(radius, $fn = fn);
+        polygon(points);
+    }
+}
+
+
+module pcb_xy_placement() {
+    translate([0, get_magnet_hole_offset()]) {
+        // Translate so the sensor is at the origin
+        translate([-pcb_hole_to_sensor_x(), pcb_hole_to_sensor_y()]) {
+            rotate([180,0,0]) {
+                children();
+            }
+        }
+    }
+
+}
+
+
+inner_radius = 28byj48_chassis_radius() + 1;
+outer_radius = 28byj48_mount_center_offset() + 5;
+
+fillet = 5;
+
+module motor_mount_positive() {
+    translate([0, -28byj48_shaft_offset()]) {
+                hull() {
+                    sector(outer_radius, [0, 180]);
+                    translate([-outer_radius+fillet, 0]) {
+                        circle(r=fillet);
+                    }
+                    translate([outer_radius-fillet, 0]) {
+                        circle(r=fillet);
+                    }
+                }
+    }
+}
+module motor_mount_negative() {
+    translate([0, -28byj48_shaft_offset()]) {
+        hull() {
+            translate([28byj48_mount_center_offset(), 0]) {
+                circle(d=m4_hole_diameter);
+            }
+            translate([-28byj48_mount_center_offset(), 0]) {
+                circle(d=m4_hole_diameter);
+            }
+        }
+        sector(inner_radius, [0, 180]);
+        translate([-inner_radius, -fillet - eps])
+        square([2*inner_radius, fillet + eps]);
+    }
+}
+
+module motor_test_jig() {
+    linear_extrude(height=get_thickness()) {
+        difference() {
+            union() {
+                motor_mount_positive();
+                pcb_xy_placement() {
+                    offset(r=2) {
+                        hull() {
+                            pcb_outline_2d(false);
+                            translate([0, 5]) {
+                                pcb_outline_2d(false);
+                            }
+                        }
+                    }
+                }
+            }
+
+            motor_mount_negative();
+            pcb_xy_placement() {
+                // Expand small cutouts for 3d printing
+                offset(r=0.3) {
+                    pcb_cutouts(adjustment_range=0);
+                }
+            }
+        }
+    }
+}
+
+module magnet_arm() {
+    linear_extrude(height=get_thickness()) {
+        difference() {
+            hull() {
+                circle(r=5);
+                translate([0, get_magnet_hole_offset()]) {
+                    circle(r=3);
+                }
+            }
+            offset(r=0.2) {
+                motor_shaft();
+            }
+            translate([0, get_magnet_hole_offset()]) {
+                circle(d=get_magnet_diameter() + 0.2);
+            }
+            translate([-.4, get_magnet_hole_offset()]) {
+                square([0.8, 10]);
+            }
+        }
+    }
+}
+
+if (export) {
+    motor_test_jig();
+    translate([30, 0]) {
+        magnet_arm();
+    }
+} else {
+    dim() {
+        translate([0, 0, 28byj48_mount_bracket_height()]) {
+            Stepper28BYJ48();
+        }
+        translate([0, 0, -get_thickness()]) {
+            pcb_xy_placement() {
+                        pcb(get_pcb_to_spool());
+            }
+        }
+    }
+    translate([0, 0, -get_thickness()]) {
+        motor_test_jig();
+    }
+    translate([0, 0, 6]) {
+        magnet_arm();
+    }
+}


### PR DESCRIPTION
3d printable piece to hold a motor+sensor and a maget arm for the motor, for testing motors and sensors (e.g. gear ratio, or basic movement tests).

![motor_test_jig](https://user-images.githubusercontent.com/414890/123217175-26b0fb00-d47f-11eb-8f40-9ea0ef14bf96.png)
