### PR TITLE
Improve 3d laser artifact generation

### DIFF
--- a/.github/workflows/3d.yml
+++ b/.github/workflows/3d.yml
@@ -27,13 +27,34 @@ jobs:
 
       - name: Generate 2d output (Ponoko 3mm MDF)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --render-raster --kerf-preset ponoko-3mm-mdf
-          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf.svg
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf
+          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x.svg
+          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x_dimensions.txt
 
       - name: Generate 2d output (Ponoko 3mm Acrylic)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --render-raster --kerf-preset ponoko-3mm-acrylic
-          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic.svg
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic
+          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x.svg
+          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x_dimensions.txt
+
+      - name: Generate 2d output (Ponoko 3mm MDF - 4x)
+        run: |
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf --panelize 4
+          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.svg
+          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.txt
+
+      - name: Generate 2d output (Ponoko 3mm Acrylic - 4x)
+        run: |
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic --panelize 4
+          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x.svg
+          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x_dimensions.txt
+
+      - name: Generate 2d output (Elecrow 3mm Wood)
+        run: |
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset elecrow-3mm-wood --render-elecrow
+          cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.svg
+          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x_dimensions.txt
+          cp 3d/build/laser_parts/elecrow.pdf 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.pdf
 
       - name: Generate animated gif
         run: |

--- a/.github/workflows/3d.yml
+++ b/.github/workflows/3d.yml
@@ -27,25 +27,25 @@ jobs:
 
       - name: Generate 2d output (Ponoko 3mm MDF)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --calculate-dimensions --kerf-preset ponoko-3mm-mdf
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x.svg
           cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x_dimensions.txt
 
       - name: Generate 2d output (Ponoko 3mm Acrylic)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --calculate-dimensions --kerf-preset ponoko-3mm-acrylic
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x.svg
           cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x_dimensions.txt
 
       - name: Generate 2d output (Ponoko 3mm MDF - 4x)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf --panelize 4
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --calculate-dimensions --kerf-preset ponoko-3mm-mdf --panelize 4
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.svg
           cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.txt
 
       - name: Generate 2d output (Ponoko 3mm Acrylic - 4x)
         run: |
-          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic --panelize 4
+          xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --calculate-dimensions --kerf-preset ponoko-3mm-acrylic --panelize 4
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x.svg
           cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x_dimensions.txt
 

--- a/.github/workflows/3d.yml
+++ b/.github/workflows/3d.yml
@@ -29,31 +29,31 @@ jobs:
         run: |
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x.svg
-          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x_dimensions.txt
+          cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_1x_dimensions.txt
 
       - name: Generate 2d output (Ponoko 3mm Acrylic)
         run: |
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x.svg
-          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x_dimensions.txt
+          cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_1x_dimensions.txt
 
       - name: Generate 2d output (Ponoko 3mm MDF - 4x)
         run: |
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-mdf --panelize 4
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.svg
-          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.txt
+          cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-mdf_4x.txt
 
       - name: Generate 2d output (Ponoko 3mm Acrylic - 4x)
         run: |
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset ponoko-3mm-acrylic --panelize 4
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x.svg
-          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x_dimensions.txt
+          cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-ponoko-3mm-acrylic_4x_dimensions.txt
 
       - name: Generate 2d output (Elecrow 3mm Wood)
         run: |
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset elecrow-3mm-wood --render-elecrow
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.svg
-          cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x_dimensions.txt
+          cp 3d/build/laser_parts/combined_dimensions.txt 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x_dimensions.txt
           cp 3d/build/laser_parts/elecrow.zip 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.zip
 
       - name: Generate animated gif

--- a/.github/workflows/3d.yml
+++ b/.github/workflows/3d.yml
@@ -54,7 +54,7 @@ jobs:
           xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" python3 -u 3d/scripts/generate_2d.py --kerf-preset elecrow-3mm-wood --render-elecrow
           cp 3d/build/laser_parts/combined.svg 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.svg
           cp 3d/build/laser_parts/combined.svg_dimensions.txt 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x_dimensions.txt
-          cp 3d/build/laser_parts/elecrow.pdf 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.pdf
+          cp 3d/build/laser_parts/elecrow.zip 3d/build/outputs/3d_laser_vector-elecrow-3mm-wood_1x.zip
 
       - name: Generate animated gif
         run: |

--- a/3d/scripts/dependencies.sh
+++ b/3d/scripts/dependencies.sh
@@ -7,6 +7,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -v
 
 sudo apt-get update -qq
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openscad inkscape imagemagick xvfb
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openscad inkscape imagemagick xvfb texlive-extra-utils
 
 sudo pip install -r "$DIR/requirements.txt"

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -61,12 +61,14 @@ if __name__ == '__main__':
     parser.add_argument('--render-elecrow', action='store_true', help='Render an additional zipped pdf with labeled '
                                                                       'dimensions and only cut lines, for Elecrow. '
                                                                       'Requires Inkscape and pdfjam. Implies '
-                                                                      '--no-etch and --calculate-dimensions')
+                                                                      '--no-etch, --calculate-dimensions, and '
+                                                                      '--skip-optimize')
 
     args = parser.parse_args()
     if args.render_elecrow:
         args.no_etch = True
         args.calculate_dimensions = True
+        args.skip_optimize = True
 
     laser_parts_directory = os.path.join(source_parts_dir, 'build', 'laser_parts')
 

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -35,6 +35,7 @@ from util import rev_info
 KERF_PRESETS = {
     'ponoko-3mm-mdf': 0.18,
     'ponoko-3mm-acrylic': 0.1,
+    'elecrow-3mm-wood': 0.185,
 }
 
 if __name__ == '__main__':
@@ -50,12 +51,21 @@ if __name__ == '__main__':
 
     parser.add_argument('--render-raster', action='store_true', help='Render raster PNG from the output SVG (requires '
                                                                      'Inkscape)')
+    parser.add_argument('--calculate-dimensions', action='store_true', help='Calculate overall cut file dimensions ('
+                                                                            'requires Inkscape)')
     parser.add_argument('--thickness', type=float, help='Override panel thickness value')
     parser.add_argument('--no-etch', action='store_true', help='Do not render laser-etched features')
     parser.add_argument('--mirror', action='store_true', help='Mirror the assembly so the outside faces are facing up. '
                                                               'Note that this will remove all etched features.')
+    parser.add_argument('--render-elecrow', action='store_true', help='Render an additional zipped pdf with labeled '
+                                                                      'dimensions and only cut lines, for Elecrow. '
+                                                                      'Requires Inkscape and pdfjam. Implies '
+                                                                      '--no-etch and --calculate-dimensions')
 
     args = parser.parse_args()
+    if args.render_elecrow:
+        args.no_etch = True
+        args.calculate_dimensions = True
 
     laser_parts_directory = os.path.join(source_parts_dir, 'build', 'laser_parts')
 
@@ -78,16 +88,77 @@ if __name__ == '__main__':
     renderer.clean()
     svg_output = renderer.render_svgs(panelize_quantity=args.panelize)
 
-    logging.info('Removing redundant lines')
     processor = SvgProcessor(svg_output)
 
     redundant_lines, merged_lines = None, None
     if not args.skip_optimize:
+        logging.info('Removing redundant lines')
         redundant_lines, merged_lines = processor.remove_redundant_lines()
 
     processor.write(svg_output)
+    logging.info(f'\n\n\nDone rendering to SVG: {svg_output}')
 
-    logging.info('\n\n\nDone rendering to SVG: ' + svg_output)
+    if args.calculate_dimensions:
+        svg_for_dimensions = os.path.join(laser_parts_directory, os.path.splitext(os.path.basename(svg_output))[0] + '_dimensions.svg')
+        processor.apply_dimension_calculation_style()
+        processor.write(svg_for_dimensions)
+        logging.info('Read dimensions')
+        width_px = float(subprocess.check_output([
+            'inkscape',
+            '--without-gui',
+            '--query-width',
+            svg_for_dimensions,
+        ]))
+        width_mm = width_px * 25.4 / 96 # Assuming 96dpi...
+        height_px = float(subprocess.check_output([
+            'inkscape',
+            '--without-gui',
+            '--query-height',
+            svg_for_dimensions,
+        ]))
+        height_mm = height_px * 25.4 / 96 # Assuming 96dpi...
+        dimensions_file = os.path.join(laser_parts_directory, os.path.splitext(os.path.basename(svg_output))[0] + '_dimensions.txt')
+        with open(dimensions_file, 'w') as f:
+            f.write(f'{width_mm:.2f}mm x {height_mm:.2f}mm')
+
+    if args.render_elecrow:
+        elecrow_svg = os.path.join(laser_parts_directory, 'elecrow.svg')
+        elecrow_intermediate_pdf = os.path.join(laser_parts_directory, 'elecrow_intermediate.pdf')
+        elecrow_pdf = os.path.join(laser_parts_directory, 'elecrow.pdf')
+
+        processor.apply_elecrow_style()
+        processor.add_dimensions(width_mm, height_mm)
+        processor.write(elecrow_svg)
+
+        logging.info('Resize SVG canvas')
+        subprocess.check_call([
+            'inkscape',
+            '--verb=FitCanvasToDrawing',
+            '--verb=FileSave',
+            '--verb=FileClose',
+            '--verb=FileQuit',
+            elecrow_svg,
+        ])
+
+        logging.info('Output PDF')
+        subprocess.check_call([
+            'inkscape',
+            elecrow_svg,
+            '--export-pdf',
+            elecrow_intermediate_pdf,
+        ])
+
+        logging.info('Resize PDF')
+        subprocess.check_call([
+            'pdfjam',
+            '--letterpaper',
+            '--landscape',
+            '--noautoscale',
+            'true',
+            '--outfile',
+            elecrow_pdf,
+            elecrow_intermediate_pdf,
+        ])
 
     if args.render_raster:
         # Export to png
@@ -112,6 +183,7 @@ if __name__ == '__main__':
             '--verb=FileQuit',
             raster_svg,
         ])
+
         logging.info('Export PNG')
         subprocess.check_call([
             'inkscape',

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -21,6 +21,7 @@ import logging
 import os
 import subprocess
 import sys
+import zipfile
 
 from svg_processor import SvgProcessor
 from projection_renderer import Renderer
@@ -125,6 +126,7 @@ if __name__ == '__main__':
         elecrow_svg = os.path.join(laser_parts_directory, 'elecrow.svg')
         elecrow_intermediate_pdf = os.path.join(laser_parts_directory, 'elecrow_intermediate.pdf')
         elecrow_pdf = os.path.join(laser_parts_directory, 'elecrow.pdf')
+        elecrow_zip = os.path.join(laser_parts_directory, 'elecrow.zip')
 
         processor.apply_elecrow_style()
         processor.add_dimensions(width_mm, height_mm)
@@ -159,6 +161,10 @@ if __name__ == '__main__':
             elecrow_pdf,
             elecrow_intermediate_pdf,
         ])
+
+        logging.info('Zip')
+        with zipfile.ZipFile(elecrow_zip, 'w', zipfile.ZIP_DEFLATED) as zip:
+            zip.write(elecrow_pdf, 'elecrow.pdf')
 
     if args.render_raster:
         # Export to png

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -95,6 +95,23 @@ class SvgProcessor(object):
                     'stroke-width': '0.2',
                 })
 
+    def apply_dimension_calculation_style(self):
+        # Remove stroke for calculating overall dimensions in Inkscape (which includes stroke)
+        for path in self.svg_node.getElementsByTagName('path'):
+                SvgProcessor._apply_attributes(path, {
+                    'fill': 'none',
+                    'stroke': 'none',
+                })
+
+    def apply_elecrow_style(self):
+        # Set fill and stroke for Elecrow ordering
+        for path in self.svg_node.getElementsByTagName('path'):
+                SvgProcessor._apply_attributes(path, {
+                    'fill': 'none',
+                    'stroke': '#000000',
+                    'stroke-width': '0.1',
+                })
+
     def import_paths(self, from_svg_processor):
         for path in from_svg_processor.svg_node.getElementsByTagName('path'):
             output_node = self.dom.importNode(path, True)
@@ -319,6 +336,35 @@ class SvgProcessor(object):
             new_path_node.setAttribute('stroke-opacity', '.45')
 
             self.svg_node.appendChild(new_path_node)
+
+    def add_dimensions(self, width_mm, height_mm):
+        width_node = self.dom.createElement("path")
+        width_node.setAttribute('d', f'M 0 10 l 0 5 l {width_mm} 0 l 0 -5')
+        width_node.setAttribute('fill', 'none')
+        width_node.setAttribute('stroke', '#ff00ff')
+        width_node.setAttribute('stroke-width', '1')
+        self.svg_node.appendChild(width_node)
+
+        width_label_node = self.dom.createElement('text')
+        width_label_node.setAttribute('x', f'{width_mm / 2}')
+        width_label_node.setAttribute('y', '25')
+        width_label_node.setAttribute('style', 'font: 5px sans-serif; fill: #ff00ff; text-anchor: middle;')
+        width_label_node.appendChild(self.dom.createTextNode(f'{width_mm:.2f} mm'))
+        self.svg_node.appendChild(width_label_node)
+
+        height_node = self.dom.createElement("path")
+        height_node.setAttribute('d', f'M -10 0 l -5 0 l 0 -{height_mm} l 5 0')
+        height_node.setAttribute('fill', 'none')
+        height_node.setAttribute('stroke', '#ff00ff')
+        height_node.setAttribute('stroke-width', '1')
+        self.svg_node.appendChild(height_node)
+
+        height_label_node = self.dom.createElement('text')
+        height_label_node.setAttribute('x', '-20')
+        height_label_node.setAttribute('y', f'{-height_mm / 2}')
+        height_label_node.setAttribute('style', 'font: 5px sans-serif; fill: #ff00ff; text-anchor: end;')
+        height_label_node.appendChild(self.dom.createTextNode(f'{height_mm:.2f} mm'))
+        self.svg_node.appendChild(height_label_node)
 
     def write(self, filename):
         with open(filename, 'w') as output_file:


### PR DESCRIPTION
- Add 4x panelized output generation
- Generate text files that describe the dimensions of each SVG file (for verifying SVG processors - e.g. Ponoko - are handling dimensions correctly)
- Add Elecrow wood kerf preset and zipped PDF generation: no etching, black lines, labeled dimensions

Example output pdf: [elecrow.pdf](https://github.com/scottbez1/splitflap/files/6751491/elecrow.pdf)
