### PR TITLE
Mounting Brackets

### DIFF
--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -82,3 +82,86 @@ module fillet_tool(r, overlap=0.01, $fn=$fn) {
                 circle(r=r, $fn=$fn);
             }
 }
+
+module fillet_tool_3d(r, r_corner=undef, overlap=0.01, $fn=$fn) {
+    corner_radius = (r_corner == undef) ? r : r_corner;  // use fillet radius if corner radius not provided
+    translate([corner_radius, corner_radius, 0])
+        rotate([0, 180, 90])
+            rotate_extrude(angle=90, convexity=10, $fn=$fn)
+                translate([corner_radius, 0, 0])
+                    rotate([0, 0, 90])
+                        fillet_tool(r, $fn);
+}
+
+module square_fillet_3d(size, r, r_corner=0.0, center=false, $fn=$fn) {
+    width  = size[0] == undef ? size : size[0];  // unpack vector if present
+    length = size[1] == undef ? size : size[1];
+
+    max_radius = min(width, length)/2;  // largest radius possible along XY
+
+    // Both radius and corner radius can be any value between 0 and the shortest
+    // edge of the rectangle / 2 (maximum radius for full round).
+    
+    // If radius is zero, no geometry is generated (no radius = no fillet)
+    // If corner radius is zero, corner rounding geometry is not generated
+    radius = (r >= max_radius) ? max_radius : r;
+
+    // if present, corner radius cannot be less than fillet radius (invalid geometry)
+    corner_radius_inter = (r_corner != 0 && r_corner < radius) ? radius : r_corner;
+
+    // corner radius cannot be greater than the max radius
+    corner_radius = min(corner_radius_inter, max_radius);
+
+    if(radius > 0) {
+        center_x = center ? -width/2 : 0;
+        center_y = center ? -length/2 : 0;
+
+        translate([center_x, center_y]) {
+            union() {
+                // X Straight, Origin
+                translate([corner_radius, 0, 0])
+                    rotate([0, 90, 0])
+                        linear_extrude(height=width - 2*corner_radius)
+                            fillet_tool(radius, $fn);
+
+                // X Straight, At Length
+                translate([width - corner_radius, length, 0])
+                    rotate([0, 90, 180])
+                        linear_extrude(height=width - 2*corner_radius)
+                            fillet_tool(radius, $fn);
+
+                // Y Straight, Origin
+                translate([0, length - corner_radius, 0])
+                    rotate([0, 90, 270])
+                        linear_extrude(height=length - 2*corner_radius)
+                            fillet_tool(radius, $fn);
+
+                // Y Straight, At Width
+                translate([width, corner_radius, 0])
+                    rotate([0, 90, 90])
+                        linear_extrude(height=length - 2*corner_radius)
+                            fillet_tool(radius, $fn);
+
+                if(corner_radius > 0) {
+                    // Corner: Bottom Left
+                    fillet_tool_3d(radius, corner_radius, $fn);
+
+                    // Corner: Bottom Right
+                    translate([width, 0, 0])
+                        rotate([0, 0, 90])
+                            fillet_tool_3d(radius, corner_radius, $fn);
+
+                    // Corner: Top Left
+                    translate([0, length, 0])
+                        rotate([0, 0, 270])
+                            fillet_tool_3d(radius, corner_radius, $fn);
+
+                    // Corner: Top Right
+                    translate([width, length, 0])
+                        rotate([0, 0, 180])
+                            fillet_tool_3d(radius, corner_radius, $fn);
+                }
+            }
+        }
+    }
+}

--- a/3d/shapes.scad
+++ b/3d/shapes.scad
@@ -165,3 +165,23 @@ module square_fillet_3d(size, r, r_corner=0.0, center=false, $fn=$fn) {
         }
     }
 }
+
+module cone(angle, base, height=undef, center=false, $fn=$fn) {
+    // where:
+    // * angle is the angle at the top of the cone, looking towards the base
+    // * base is the diameter at the bottom of the cone
+    // * height is the total height from base to top, if given
+
+    base_radius = base/2;  // convert base diameter to radius
+    full_height = base_radius / tan(angle/2);  // height to a point at the given angle
+
+    // if no height is provided or height is out of scale, extrude up to a point
+    if(height == undef || abs(height) >= full_height) {
+        cylinder(h=full_height, r1=base_radius, r2=0, center=center);
+    }
+    // if height is provided, calculate top radius for given angle
+    else {
+        top_radius = tan(angle/2) * (full_height - height);
+        cylinder(h=height, r1=base_radius, r2=top_radius, center=center);
+    }
+}

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -228,10 +228,6 @@ connector_bracket_overlap = 4;
 connector_bracket_clearance = 0.40;
 connector_bracket_depth_clearance = 0.20;
 
-// 'get' functions to extract these values for when this file is 'used' and not 'included'
-function connector_bracket_length() = connector_bracket_length_outer;
-function connector_bracket_width() = connector_bracket_width;
-
 mounting_hole_inset = m4_button_head_diameter/2 + 2;
 
 enclosure_indicator_inset = 3.0;  // inset on both X and Y
@@ -256,6 +252,21 @@ alignment_bar_fillet_radius = 1.25;
 
 alignment_bar_cutout_width = alignment_bar_diameter + (2 * alignment_bar_clearance);
 alignment_bar_center = (enclosure_length - enclosure_length_right) - alignment_bar_cutout_width/2;
+
+// 'get' functions to extract values for when this file is 'used' and not 'included'
+function thickness() = thickness; 
+function front_forward_offset() = front_forward_offset;
+function enclosure_length_right() = enclosure_length_right;
+function enclosure_height_lower() = enclosure_height_lower;
+function enclosure_wall_to_wall_width() = enclosure_wall_to_wall_width;
+function enclosure_vertical_inset() = enclosure_vertical_inset;
+function captive_nut_inset() = captive_nut_inset;
+function mounting_hole_inset() = mounting_hole_inset;
+function side_tab_width() = side_tab_width;
+
+function connector_bracket_length() = connector_bracket_length_outer;
+function connector_bracket_width() = connector_bracket_width;
+
 
 
 echo(kerf_width=kerf_width);
@@ -1340,108 +1351,3 @@ if (render_3d) {
         }
     }
 }
-
-
-module position_mounting_bracket() {
-    translate([thickness, -enclosure_length_right + front_forward_offset, -enclosure_height_lower]) {
-        children();
-    }
-}
-
-function mounting_bracket_width(side_clearance) = enclosure_wall_to_wall_width - 2 * thickness - 2 * side_clearance;
-function mounting_bracket_length(front_clearance) = enclosure_length_right - front_clearance; 
-
-module mounting_bracket_2d(hole_diameter, clearance) {
-    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
-
-    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
-    front_clearance = unpack(clearance, 1);  // Y clearance between the mount and the front of the enclosure
-
-    difference() {
-        // base geometry
-        translate([side_clearance, 0, 0])
-            square([mounting_bracket_width(side_clearance), mounting_bracket_length(front_clearance)]);
-
-        // mounting hole
-        translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset]) {
-            circle(r=hole_diameter/2, $fn=30);
-        }
-    }
-}
-
-module mounting_bracket_base(hole_diameter=m4_hole_diameter, clearance=[0.1, 0.1, 0.2]) {
-    module bolt_negative() {
-        bolt_negative_scale = [1.2, 1.2, 1];
-        bolt_negative_length = 13;
-
-        scale(bolt_negative_scale)
-            standard_m4_bolt(captive_nut_inset, bolt_negative_length);
-    }
-
-    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
-    height_clearance = unpack(clearance, 2);  // Z clearance between the mount and the 'bottom' piece of the enclosure
-
-    difference() {
-        // Base geometry, 3D
-        linear_extrude(height=enclosure_vertical_inset - height_clearance, convexity=10)
-            mounting_bracket_2d(hole_diameter, clearance);
-
-        bolt_y_offset = enclosure_length_right - (thickness + 1.5 * side_tab_width);
-        bolt_z_offset = enclosure_vertical_inset + thickness/2;
-
-        // Left side bolt
-        translate([-thickness + enclosure_wall_to_wall_width, bolt_y_offset, bolt_z_offset])
-            rotate([180, 90, 0])
-                bolt_negative();
-
-        // Right side bolt
-        translate([-thickness, bolt_y_offset, bolt_z_offset])
-            rotate([0, 90, 0])
-                bolt_negative();
-
-        // Front Bolt
-        translate([enclosure_wall_to_wall_width/2 - thickness, enclosure_length_right + thickness, bolt_z_offset]) {
-            rotate([0, 90, -90])
-                bolt_negative();
-        }
-    }
-}
-
-module mounting_bracket_t_slot(hole_diameter=m4_hole_diameter, slot_width=6, slot_depth=5, nut_length=12.5, clearance=[0.1, 0.1, 0.2]) {
-    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
-    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
-
-    union() {
-        mounting_bracket_base(hole_diameter, clearance);
-
-        difference() {
-            // T-Slot Boss
-            mirror([0, 0, 1])
-            difference() {
-            linear_extrude(height=slot_depth)
-                difference() {
-                    // Base Geometry
-                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
-                        rounded_square([mounting_bracket_width(side_clearance), slot_width], center=true, r=5, $fn=60);
-
-                    // T-Nut Subtraction
-                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
-                        square([nut_length, slot_width + eps], center=true);
-                }
-            
-
-            }
-            // Fillet
-            translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
-                translate([0, 0, -slot_depth])
-                    mirror([0, 0, 1])
-                        square_fillet_3d([mounting_bracket_width(side_clearance), slot_width], r=5/2, r_corner=5, center=true, $fn=60);
-        }
-    }
-}
-
-
-position_mounting_bracket() {
-    mounting_bracket_t_slot();
-}
-

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -279,20 +279,24 @@ echo(flap_notch_height=flap_notch_height);
 echo(pcb_to_sensor=pcb_to_sensor(pcb_to_spool));
 
 
-module standard_m4_bolt(nut_distance=-1) {
+module standard_m4_bolt(nut_distance=-1, bolt_length=10) {
     if (render_bolts) {
         color(bolt_color)
-            roughM4_7380(10);
+            roughM4_7380(bolt_length);
         if (nut_distance >= 0) {
-            color(nut_color) {
-                translate([0, 0, nut_distance]) {
-                    linear_extrude(m4_nut_length) {
-                        difference() {
-                            circle(r=m4_nut_width_corners/2, $fn=6);
-                            circle(r=m4_hole_diameter/2, $fn=20);
-                        }
-                    }
-                }
+            translate([0, 0, nut_distance])
+                standard_m4_nut();
+        }
+    }
+}
+
+module standard_m4_nut(hole=false) {
+    color(nut_color) {
+        linear_extrude(m4_nut_length) {
+            difference() {
+                circle(r=m4_nut_width_corners/2, $fn=6);
+                if(hole == true)
+                    circle(r=m4_hole_diameter/2, $fn=20);
             }
         }
     }
@@ -1336,3 +1340,108 @@ if (render_3d) {
         }
     }
 }
+
+
+module position_mounting_bracket() {
+    translate([thickness, -enclosure_length_right + front_forward_offset, -enclosure_height_lower]) {
+        children();
+    }
+}
+
+function mounting_bracket_width(side_clearance) = enclosure_wall_to_wall_width - 2 * thickness - 2 * side_clearance;
+function mounting_bracket_length(front_clearance) = enclosure_length_right - front_clearance; 
+
+module mounting_bracket_2d(hole_diameter, clearance) {
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+
+    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
+    front_clearance = unpack(clearance, 1);  // Y clearance between the mount and the front of the enclosure
+
+    difference() {
+        // base geometry
+        translate([side_clearance, 0, 0])
+            square([mounting_bracket_width(side_clearance), mounting_bracket_length(front_clearance)]);
+
+        // mounting hole
+        translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset]) {
+            circle(r=hole_diameter/2, $fn=30);
+        }
+    }
+}
+
+module mounting_bracket_base(hole_diameter=m4_hole_diameter, clearance=[0.1, 0.1, 0.2]) {
+    module bolt_negative() {
+        bolt_negative_scale = [1.2, 1.2, 1];
+        bolt_negative_length = 13;
+
+        scale(bolt_negative_scale)
+            standard_m4_bolt(captive_nut_inset, bolt_negative_length);
+    }
+
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+    height_clearance = unpack(clearance, 2);  // Z clearance between the mount and the 'bottom' piece of the enclosure
+
+    difference() {
+        // Base geometry, 3D
+        linear_extrude(height=enclosure_vertical_inset - height_clearance, convexity=10)
+            mounting_bracket_2d(hole_diameter, clearance);
+
+        bolt_y_offset = enclosure_length_right - (thickness + 1.5 * side_tab_width);
+        bolt_z_offset = enclosure_vertical_inset + thickness/2;
+
+        // Left side bolt
+        translate([-thickness + enclosure_wall_to_wall_width, bolt_y_offset, bolt_z_offset])
+            rotate([180, 90, 0])
+                bolt_negative();
+
+        // Right side bolt
+        translate([-thickness, bolt_y_offset, bolt_z_offset])
+            rotate([0, 90, 0])
+                bolt_negative();
+
+        // Front Bolt
+        translate([enclosure_wall_to_wall_width/2 - thickness, enclosure_length_right + thickness, bolt_z_offset]) {
+            rotate([0, 90, -90])
+                bolt_negative();
+        }
+    }
+}
+
+module mounting_bracket_t_slot(hole_diameter=m4_hole_diameter, slot_width=6, slot_depth=5, nut_length=12.5, clearance=[0.1, 0.1, 0.2]) {
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
+
+    union() {
+        mounting_bracket_base(hole_diameter, clearance);
+
+        difference() {
+            // T-Slot Boss
+            mirror([0, 0, 1])
+            difference() {
+            linear_extrude(height=slot_depth)
+                difference() {
+                    // Base Geometry
+                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                        rounded_square([mounting_bracket_width(side_clearance), slot_width], center=true, r=5, $fn=60);
+
+                    // T-Nut Subtraction
+                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                        square([nut_length, slot_width + eps], center=true);
+                }
+            
+
+            }
+            // Fillet
+            translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                translate([0, 0, -slot_depth])
+                    mirror([0, 0, 1])
+                        square_fillet_3d([mounting_bracket_width(side_clearance), slot_width], r=5/2, r_corner=5, center=true, $fn=60);
+        }
+    }
+}
+
+
+position_mounting_bracket() {
+    mounting_bracket_t_slot();
+}
+

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -301,7 +301,7 @@ module standard_m4_bolt(nut_distance=-1, bolt_length=10) {
     }
 }
 
-module standard_m4_nut(hole=false) {
+module standard_m4_nut(hole=true) {
     color(nut_color) {
         linear_extrude(m4_nut_length) {
             difference() {

--- a/3d/tools/mounting_bracket.scad
+++ b/3d/tools/mounting_bracket.scad
@@ -157,7 +157,7 @@ module mounting_bracket_screw_holes(hole_diameter=m4_hole_diameter, screw_diamet
     height_clearance = unpack(clearance, 2);  // Z clearance between the mount and the 'bottom' piece of the enclosure
 
     width = mounting_bracket_width(side_clearance);  // width of the mount
-    height = mounting_bracket_height(height_clearance) + thickness;  // height of the mount, including screw area
+    height = mounting_bracket_height(height_clearance) + thickness + height_clearance;  // height of the screw area on the mount
 
     screw_area_radius = r;  // radius for the fillet on the screw area extension
     screw_area_depth = screw_diameter + 2*screw_clearance + screw_area_radius;  // Y distance of the screw area extension

--- a/3d/tools/mounting_bracket.scad
+++ b/3d/tools/mounting_bracket.scad
@@ -1,0 +1,138 @@
+/*
+   Copyright 2021 Scott Bezek and the splitflap contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use<../splitflap.scad>;
+use<../shapes.scad>;
+
+include<../m4_dimensions.scad>;
+
+// Constants from splitflap.scad, using functions to extract
+thickness = thickness();
+front_forward_offset = front_forward_offset();
+enclosure_length_right = enclosure_length_right();
+enclosure_height_lower = enclosure_height_lower();
+enclosure_wall_to_wall_width = enclosure_wall_to_wall_width();
+enclosure_vertical_inset = enclosure_vertical_inset();
+captive_nut_inset = captive_nut_inset();
+mounting_hole_inset = mounting_hole_inset();
+side_tab_width = side_tab_width();
+
+eps = 0.01;
+
+module position_mounting_bracket() {
+    translate([thickness, -enclosure_length_right + front_forward_offset, -enclosure_height_lower]) {
+        children();
+    }
+}
+
+function mounting_bracket_width(side_clearance) = enclosure_wall_to_wall_width - 2 * thickness - 2 * side_clearance;
+function mounting_bracket_length(front_clearance) = enclosure_length_right - front_clearance; 
+
+module mounting_bracket_2d(hole_diameter, clearance) {
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+
+    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
+    front_clearance = unpack(clearance, 1);  // Y clearance between the mount and the front of the enclosure
+
+    difference() {
+        // base geometry
+        translate([side_clearance, 0, 0])
+            square([mounting_bracket_width(side_clearance), mounting_bracket_length(front_clearance)]);
+
+        // mounting hole
+        translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset]) {
+            circle(r=hole_diameter/2, $fn=30);
+        }
+    }
+}
+
+module mounting_bracket_base(hole_diameter=m4_hole_diameter, clearance=[0.1, 0.1, 0.2]) {
+    module bolt_negative() {
+        bolt_negative_scale = [1.2, 1.2, 1];
+        bolt_negative_length = 13;
+
+        scale(bolt_negative_scale)
+            standard_m4_bolt(captive_nut_inset, bolt_negative_length);
+    }
+
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+    height_clearance = unpack(clearance, 2);  // Z clearance between the mount and the 'bottom' piece of the enclosure
+
+    difference() {
+        // base geometry, 3D
+        linear_extrude(height=enclosure_vertical_inset - height_clearance, convexity=10)
+            mounting_bracket_2d(hole_diameter, clearance);
+
+        bolt_y_offset = enclosure_length_right - (thickness + 1.5 * side_tab_width);
+        bolt_z_offset = enclosure_vertical_inset + thickness/2;
+
+        // left side bolt
+        translate([-thickness + enclosure_wall_to_wall_width, bolt_y_offset, bolt_z_offset])
+            rotate([180, 90, 0])
+                bolt_negative();
+
+        // right side bolt
+        translate([-thickness, bolt_y_offset, bolt_z_offset])
+            rotate([0, 90, 0])
+                bolt_negative();
+
+        // front bolt
+        translate([enclosure_wall_to_wall_width/2 - thickness, enclosure_length_right + thickness, bolt_z_offset]) {
+            rotate([0, 90, -90])
+                bolt_negative();
+        }
+    }
+}
+
+module mounting_bracket_t_slot(hole_diameter=m4_hole_diameter, slot_width=6, slot_depth=5, nut_length=12.5, clearance=[0.1, 0.1, 0.2]) {
+    function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
+
+    side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
+
+    boss_width = mounting_bracket_width(side_clearance) - 2;
+    fillet_radius = slot_width - 1;
+
+    union() {
+        // 3D base geometry
+        mounting_bracket_base(hole_diameter, clearance);
+
+        difference() {
+            // t-slot boss
+            mirror([0, 0, 1])
+                difference() {
+                    linear_extrude(height=slot_depth)
+                        difference() {
+                            // base geometry
+                            translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                                rounded_square([boss_width, slot_width], center=true, r=fillet_radius, $fn=60);
+
+                            // t-nut subtraction
+                            translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                                square([nut_length, slot_width + eps], center=true);
+                        }
+                }
+
+            // rounded fillet
+            translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset])
+                translate([0, 0, -slot_depth])
+                    mirror([0, 0, 1])
+                        square_fillet_3d([boss_width, slot_width], r=fillet_radius/2, r_corner=fillet_radius, center=true, $fn=60);
+        }
+    }
+}
+
+
+mounting_bracket_t_slot();

--- a/3d/tools/mounting_bracket.scad
+++ b/3d/tools/mounting_bracket.scad
@@ -201,7 +201,7 @@ module mounting_bracket_screw_holes(hole_diameter=m4_hole_diameter, screw_diamet
                 }
 
                 // screw holes
-                translate([screw_left_inset, 2*screw_area_radius + screw_clearance, -eps]) {
+                translate([screw_left_inset, screw_area_depth/2 + screw_area_radius/2, -eps]) {
                     if(num_screws == 1) {
                         translate([screw_spacing, 0, 0])
                             screw_hole();

--- a/3d/tools/mounting_bracket.scad
+++ b/3d/tools/mounting_bracket.scad
@@ -62,11 +62,25 @@ module mounting_bracket_2d(hole_diameter, clearance) {
 
 module mounting_bracket_base(hole_diameter=m4_hole_diameter, clearance=[0.1, 0.1, 0.2]) {
     module bolt_negative() {
-        bolt_negative_scale = [1.2, 1.2, 1];
-        bolt_negative_length = 13;
+        cutout_negative_scale = [1.2, 1.2, 1];  // scale factors for the increased sizes
+        bolt_negative_length = 13;  // length of the bolt cutout
+        nut_negative_excess_thickness = 1;  // extra thickness around the nut negative
 
-        scale(bolt_negative_scale)
-            standard_m4_bolt(captive_nut_inset, bolt_negative_length);
+        union() {
+            scale(cutout_negative_scale) {
+                // bolt negative
+                standard_m4_bolt(bolt_length=bolt_negative_length);
+            
+                // nut negative
+                translate([0, 0, captive_nut_inset - nut_negative_excess_thickness/2])
+                    // note that we're using projection and linear extrusion here so
+                    // that we can center the extra thickness on both sides of the nut,
+                    // rather than putting it all just on one side as with 'scale()'
+                    linear_extrude(height=m4_nut_length + nut_negative_excess_thickness)
+                        projection()
+                            standard_m4_nut(hole=false);
+            }
+        }
     }
 
     function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise

--- a/3d/tools/mounting_bracket.scad
+++ b/3d/tools/mounting_bracket.scad
@@ -150,7 +150,7 @@ module mounting_bracket_t_slot(hole_diameter=m4_hole_diameter, slot_width=6, slo
 }
 
 
-module mounting_bracket_screw_holes(hole_diameter=m4_hole_diameter, screw_diameter=m4_hole_diameter, num_screws=2, screw_clearance=4, screw_inset=8, countersink=8.5, r=2.5, clearance=[0.1, 0.1, 0.2]) {
+module mounting_bracket_screw_holes(hole_diameter=m4_hole_diameter, screw_diameter=m4_hole_diameter, num_screws=2, screw_clearance=4, screw_inset=8, csk=9, csk_angle=82, r=2.5, clearance=[0.1, 0.1, 0.2]) {
     function unpack(val, pos) = (val[pos] == undef) ? 0 : val[pos];  // use vector if possible, 0 otherwise
 
     side_clearance  = unpack(clearance, 0);  // X clearance between the mount and the sides of the enclosure (each side)
@@ -173,10 +173,10 @@ module mounting_bracket_screw_holes(hole_diameter=m4_hole_diameter, screw_diamet
                 circle(r=screw_diameter/2, $fn=60);
 
             // countersinks
-            if(countersink > 0) {
+            if(csk > 0) {
                 translate([0, 0, height + 2*eps])
                     rotate([0, 180, 0])
-                        cone(angle=82, base=countersink, $fn=60);
+                        cone(angle=csk_angle, base=csk, $fn=60);
             }
         }
     }


### PR DESCRIPTION
Creates `mounting_bracket.scad` which generates geometry for 3D-printable mounting brackets. Two brackets are defined, using the same common base geometry:

* `mounting_bracket_t_slot` for mounting a module to an M4-sized T-slot, using an M4-12 bolt and matching T-nut.
* `mounting_bracket_screw_holes` for mounting a module to a wooden board using flat-head M4 screws. The hole for the enclosure's bolt either needs to be undersized for thread engagement or enlarged for a heat-set insert (user's choice).

The base geometry uses the existing hole in the bottom enclosure piece and juts up against the left and right enclosure sides to prevent the module from twisting.

This also adds three more functions to `shapes.scad`: one to create a 3D rounded fillet on a corner, one to create a 3D rounded fillet on an extruded rectangle, and one to create a cone at a specified angle (needed for the 82° countersunk holes).

### T-Slot Mount
![sf-mount-adapter-tslot-top](https://user-images.githubusercontent.com/24282108/124343846-a5ebb080-db9c-11eb-95a8-8ac1b1557875.png)

![sf-mount-adapter-tslot-bottom](https://user-images.githubusercontent.com/24282108/124343849-ac7a2800-db9c-11eb-90bc-b83049f2e197.png)

![sf-mount-adapter-tslot-positioned](https://user-images.githubusercontent.com/24282108/124344535-d9c8d500-dba0-11eb-8bc0-ce277a72a314.png)

### Screw Mount

![sf-mount-adapter-screws](https://user-images.githubusercontent.com/24282108/124343853-b1d77280-db9c-11eb-904b-dddf4d9cb212.png)

![sf-mount-adapter-screws-positioned](https://user-images.githubusercontent.com/24282108/124344543-dd5c5c00-dba0-11eb-9b45-312078bb2fc1.png)

For viewing the mounts in position use this snippet in a new file:

```
include <splitflap.scad>
use <tools/mounting_bracket.scad>

position_mounting_bracket() {
    mounting_bracket_t_slot();
    //mounting_bracket_screw_holes();
}
```
I've printed both of these mounts for testing and they work great.