### PR TITLE
Tool/model for laying out a merged front panel

### DIFF
--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -102,10 +102,10 @@ for (i=[0:cols-1]) {
     for (j=[0:rows-1]) {
         index = i + j*cols;
         translate([i * layout_center_center_x, -j * layout_center_center_y]) {
-            translate([-flap_width/2, get_flap_gap()/2]) {
+            translate([-flap_width/2, 0]) {
                 flap_with_letters(text_color, flap_color, get_flap_index_for_letter(display_text[j][i]), get_flap_gap());
             }
-            translate([-flap_width/2, -get_flap_gap()/2]) {
+            translate([-flap_width/2, -(get_flap_gap() + get_flap_pin_width())]) {
                 rotate([-180, 0, 0])
                     flap_with_letters(text_color, flap_color, get_flap_index_for_letter(display_text[j][i])-1, get_flap_gap());
             }

--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -15,6 +15,8 @@
 */
 
 include<flap_dimensions.scad>;
+
+use<color_util.scad>;
 use<flap.scad>;
 use<projection_renderer.scad>;
 use<splitflap.scad>;
@@ -51,8 +53,8 @@ display_text = [
     "                 .",
 ];
 
-flap_color = [0.9, 0.9, 0.9];
-text_color = [0.15, 0.15, 0.15];
+// Number of full modules, rather than just flaps, to render in 3d
+render_full_modules_count = 4;
 
 // ---------------------------
 // End configurable parameters
@@ -76,19 +78,25 @@ module centered_front() {
     }
 }
 
-projection_renderer(render_index = render_index, render_etch = render_etch, kerf_width = kerf_width, panel_height = 0, panel_horizontal = 0, panel_vertical = 0) {
-    color([0.1, 0.1, 0.1])
-    linear_extrude(height=get_thickness()) {
-        difference() {
-            translate([(cols-1)/2 * layout_center_center_x, -(rows-1)/2 * layout_center_center_y]) {
-                square([frame_width, frame_height], center=true);
-            }
+flap_color = get_flap_color();
+letter_color = get_letter_color();
+assembly_colors = get_assembly_colors();
+frame_color = assembly_colors[0];
 
-            for (i=[0:cols-1]) {
-                for (j=[0:rows-1]) {
-                    translate([i * layout_center_center_x, -j * layout_center_center_y]) {
-                        centered_front() {
-                            enclosure_front_cutouts_2d(tool_diameter=tool_diameter);
+projection_renderer(render_index = render_index, render_etch = render_etch, kerf_width = kerf_width, panel_height = 0, panel_horizontal = 0, panel_vertical = 0) {
+    color(frame_color) {
+        linear_extrude(height=get_thickness()) {
+            difference() {
+                translate([(cols-1)/2 * layout_center_center_x, -(rows-1)/2 * layout_center_center_y]) {
+                    square([frame_width, frame_height], center=true);
+                }
+
+                for (i=[0:cols-1]) {
+                    for (j=[0:rows-1]) {
+                        translate([i * layout_center_center_x, -j * layout_center_center_y]) {
+                            centered_front() {
+                                enclosure_front_cutouts_2d(tool_diameter=tool_diameter);
+                            }
                         }
                     }
                 }
@@ -102,12 +110,22 @@ for (i=[0:cols-1]) {
     for (j=[0:rows-1]) {
         index = i + j*cols;
         translate([i * layout_center_center_x, -j * layout_center_center_y]) {
-            translate([-flap_width/2, 0]) {
-                flap_with_letters(text_color, flap_color, get_flap_index_for_letter(display_text[j][i]), get_flap_gap());
-            }
-            translate([-flap_width/2, -(get_flap_gap() + get_flap_pin_width())]) {
-                rotate([-180, 0, 0])
-                    flap_with_letters(text_color, flap_color, get_flap_index_for_letter(display_text[j][i])-1, get_flap_gap());
+            if (index < render_full_modules_count) {
+                translate([get_front_window_right_inset() + get_front_window_width()/2, 0, -get_front_forward_offset()]) {
+                    rotate([90, 0, 180]) {
+                        split_flap_3d(get_flap_index_for_letter(display_text[j][i]), false, false);
+                    }
+                }
+            } else {
+                // Render just a flap
+                translate([-flap_width/2, 0]) {
+                    flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i]), get_flap_gap());
+                }
+                translate([-flap_width/2, -(get_flap_gap() + get_flap_pin_width())]) {
+                    rotate([-180, 0, 0]) {
+                        flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i])-1, get_flap_gap());
+                    }
+                }
             }
         }
     }

--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -1,0 +1,107 @@
+/*
+   Copyright 2021 Scott Bezek and the splitflap contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+include<flap_dimensions.scad>;
+use<projection_renderer.scad>;
+use<splitflap.scad>;
+
+rows = 6;
+cols = 18;
+
+frame_width = 96*25.4;
+frame_height = 48*25.4;
+
+// Set either the center_center_* or gap_* values to distribute modules based on center-to-center distance or a gap between modules
+center_center_x = 4*25.4;
+center_center_y = 7.25*25.4;
+
+gap_x = undef;
+gap_y = undef;
+
+
+render_index = -1;
+render_etch = false;
+
+kerf_width = 0.18;
+
+
+
+assert(is_undef(center_center_x) || center_center_x >= get_enclosure_width(), "Horizontal center-to-center value must be at least the enclosure width");
+assert(is_undef(center_center_y) || center_center_y >= get_enclosure_height(), "Vertical center-to-center value must be at least the enclosure height");
+assert(is_undef(gap_x) || gap_x >= 0);
+assert(is_undef(gap_y) || gap_y >= 0);
+
+layout_center_center_x = is_undef(center_center_x) ? get_enclosure_width() + gap_x : center_center_x;
+layout_center_center_y = is_undef(center_center_y) ? get_enclosure_height() + gap_y : center_center_y;
+
+module centered_front() {
+    translate([-get_front_window_right_inset() - get_front_window_width()/2, -get_enclosure_height_lower()]) {
+        children();
+    }
+}
+
+//projection_renderer(render_index = render_index, render_etch = render_etch, kerf_width = kerf_width, panel_height = 0, panel_horizontal = 0, panel_vertical = 0) {
+
+//}
+
+color("red")
+translate([(cols-1)/2 * layout_center_center_x - center_center_x*6*1.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
+    square([center_center_x*6, frame_height], center=true);
+}
+color("green")
+translate([(cols-1)/2 * layout_center_center_x - center_center_x*6*0.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
+    square([center_center_x*6, frame_height], center=true);
+}
+color("pink")
+translate([(cols-1)/2 * layout_center_center_x + center_center_x*6*0.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
+    square([center_center_x*6, frame_height], center=true);
+}
+color("orange")
+translate([(cols-1)/2 * layout_center_center_x + center_center_x*6*1.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
+    square([center_center_x*6, frame_height], center=true);
+}
+
+color([0.5, 0.5, 0.5, 0.2])
+render(convexity = 2) {
+    difference() {
+        translate([(cols-1)/2 * layout_center_center_x, -(rows-1)/2 * layout_center_center_y]) {
+            square([frame_width, frame_height], center=true);
+        }
+
+        for (i=[0:cols-1]) {
+            for (j=[0:rows-1]) {
+                translate([i * layout_center_center_x, -j * layout_center_center_y]) {
+                    centered_front() {
+                        enclosure_front_cutouts_2d();
+                    }
+                }
+            }
+        }
+    }
+}
+
+for (i=[0:cols-1]) {
+    for (j=[0:rows-1]) {
+        translate([i * layout_center_center_x, -j * layout_center_center_y]) {
+            translate([-flap_width/2, get_flap_gap()/2]) {
+                flap();
+            }
+            translate([-flap_width/2, -get_flap_gap()/2]) {
+                rotate([-180, 0, 0])
+                    flap();
+            }
+        }
+    }
+}

--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
 include<flap_dimensions.scad>;
+use<flap.scad>;
 use<projection_renderer.scad>;
 use<splitflap.scad>;
 
@@ -34,7 +36,7 @@ gap_y = undef;
 render_index = -1;
 render_etch = false;
 
-kerf_width = 0.18;
+kerf_width = 0;
 
 
 
@@ -52,39 +54,19 @@ module centered_front() {
     }
 }
 
-//projection_renderer(render_index = render_index, render_etch = render_etch, kerf_width = kerf_width, panel_height = 0, panel_horizontal = 0, panel_vertical = 0) {
+projection_renderer(render_index = render_index, render_etch = render_etch, kerf_width = kerf_width, panel_height = 0, panel_horizontal = 0, panel_vertical = 0) {
+    linear_extrude(height=get_thickness()) {
+        difference() {
+            translate([(cols-1)/2 * layout_center_center_x, -(rows-1)/2 * layout_center_center_y]) {
+                square([frame_width, frame_height], center=true);
+            }
 
-//}
-
-color("red")
-translate([(cols-1)/2 * layout_center_center_x - center_center_x*6*1.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
-    square([center_center_x*6, frame_height], center=true);
-}
-color("green")
-translate([(cols-1)/2 * layout_center_center_x - center_center_x*6*0.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
-    square([center_center_x*6, frame_height], center=true);
-}
-color("pink")
-translate([(cols-1)/2 * layout_center_center_x + center_center_x*6*0.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
-    square([center_center_x*6, frame_height], center=true);
-}
-color("orange")
-translate([(cols-1)/2 * layout_center_center_x + center_center_x*6*1.5, -(rows-1)/2 * layout_center_center_y, -1.1]) {
-    square([center_center_x*6, frame_height], center=true);
-}
-
-color([0.5, 0.5, 0.5, 0.2])
-render(convexity = 2) {
-    difference() {
-        translate([(cols-1)/2 * layout_center_center_x, -(rows-1)/2 * layout_center_center_y]) {
-            square([frame_width, frame_height], center=true);
-        }
-
-        for (i=[0:cols-1]) {
-            for (j=[0:rows-1]) {
-                translate([i * layout_center_center_x, -j * layout_center_center_y]) {
-                    centered_front() {
-                        enclosure_front_cutouts_2d();
+            for (i=[0:cols-1]) {
+                for (j=[0:rows-1]) {
+                    translate([i * layout_center_center_x, -j * layout_center_center_y]) {
+                        centered_front() {
+                            enclosure_front_cutouts_2d();
+                        }
                     }
                 }
             }
@@ -92,15 +74,16 @@ render(convexity = 2) {
     }
 }
 
+%
 for (i=[0:cols-1]) {
     for (j=[0:rows-1]) {
         translate([i * layout_center_center_x, -j * layout_center_center_y]) {
             translate([-flap_width/2, get_flap_gap()/2]) {
-                flap();
+                flap_with_letters([1, 1, 1], [0, 0, 0], 1, get_flap_gap());
             }
             translate([-flap_width/2, -get_flap_gap()/2]) {
                 rotate([-180, 0, 0])
-                    flap();
+                    flap_with_letters([1, 1, 1], [0, 0, 0], 0, get_flap_gap());
             }
         }
     }

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import zipfile
 
+from kerf_presets import KERF_PRESETS
 from svg_processor import SvgProcessor
 from projection_renderer import Renderer
 
@@ -32,12 +33,6 @@ repo_root = os.path.dirname(source_parts_dir)
 sys.path.append(repo_root)
 
 from util import rev_info
-
-KERF_PRESETS = {
-    'ponoko-3mm-mdf': 0.18,
-    'ponoko-3mm-acrylic': 0.1,
-    'elecrow-3mm-wood': 0.185,
-}
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/3d/scripts/generate_combined_front_panel.py
+++ b/3d/scripts/generate_combined_front_panel.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+#   Copyright 2021 Scott Bezek and the splitflap contributors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import logging
+import os
+import sys
+
+from kerf_presets import KERF_PRESETS
+from svg_processor import SvgProcessor
+from projection_renderer import Renderer
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+source_parts_dir = os.path.dirname(script_dir)
+repo_root = os.path.dirname(source_parts_dir)
+sys.path.append(repo_root)
+
+def render(extra_variables, output_directory):
+    renderer = Renderer(os.path.join(source_parts_dir, 'combined_front_panel.scad'), output_directory, extra_variables)
+    renderer.clean()
+    svg_output = renderer.render_svgs(panelize_quantity = 1)
+    logging.info('\n\n\nDone rendering to SVG: ' + svg_output)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser("")
+
+    kerf_group = parser.add_mutually_exclusive_group()
+    kerf_group.add_argument('--kerf', type=float, help='Override kerf_width value')
+    kerf_group.add_argument('--kerf-preset', choices=KERF_PRESETS, help='Override kerf_width using a defined preset')
+
+    parser.add_argument('--rows', type=int, help='Number of rows')
+    parser.add_argument('--cols', type=int, help='Number of columns')
+
+    x_group = parser.add_mutually_exclusive_group()
+    x_group.add_argument('--spacing-x', type=float, help='Horizontal gap between modules')
+    x_group.add_argument('--center-center-x', type=float, help='Horizontal center-to-center distance between modules')
+
+    y_group = parser.add_mutually_exclusive_group()
+    y_group.add_argument('--spacing-y', type=float, help='Vertical gap between modules')
+    y_group.add_argument('--center-center-y', type=float, help='Vertical center-to-center distance between modules')
+
+    width = parser.add_argument('--width', type=float, help='Width of the panel')
+    height = parser.add_argument('--height', type=float, help='Height of the panel')
+
+    args = parser.parse_args()
+
+    extra_variables = {
+        'render_etch': False,
+    }
+    if args.kerf is not None:
+        extra_variables['kerf_width'] = args.kerf
+    elif args.kerf_preset is not None:
+        extra_variables['kerf_width'] = KERF_PRESETS[args.kerf_preset]
+
+    if args.rows is not None:
+        extra_variables['rows'] = args.rows
+    if args.cols is not None:
+        extra_variables['cols'] = args.cols
+
+    if args.spacing_x is not None:
+        extra_variables['gap_x'] = args.spacing_x
+    if args.spacing_y is not None:
+        extra_variables['gap_y'] = args.spacing_y
+    if args.center_center_x is not None:
+        extra_variables['center_center_x'] = center_center_x
+    if args.center_center_y is not None:
+        extra_variables['center_center_y'] = center_center_y
+
+    if args.width is not None:
+        extra_variables['frame_width'] = args.width
+    if args.height is not None:
+        extra_variables['frame_height'] = args.height
+
+    output_dir = os.path.join(source_parts_dir, 'build', 'front_panel')
+
+    render(extra_variables, output_dir)

--- a/3d/scripts/generate_combined_front_panel.py
+++ b/3d/scripts/generate_combined_front_panel.py
@@ -60,6 +60,8 @@ if __name__ == '__main__':
     width = parser.add_argument('--width', type=float, help='Width of the panel')
     height = parser.add_argument('--height', type=float, help='Height of the panel')
 
+    tool_diameter = parser.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
+
     args = parser.parse_args()
 
     extra_variables = {
@@ -88,6 +90,9 @@ if __name__ == '__main__':
         extra_variables['frame_width'] = args.width
     if args.height is not None:
         extra_variables['frame_height'] = args.height
+
+    if args.tool_diameter is not None:
+        extra_variables['tool_diameter'] = args.tool_diameter
 
     output_dir = os.path.join(source_parts_dir, 'build', 'front_panel')
 

--- a/3d/scripts/kerf_presets.py
+++ b/3d/scripts/kerf_presets.py
@@ -1,0 +1,6 @@
+
+KERF_PRESETS = {
+    'ponoko-3mm-mdf': 0.18,
+    'ponoko-3mm-acrylic': 0.1,
+    'elecrow-3mm-wood': 0.185,
+}

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -254,6 +254,7 @@ function get_enclosure_wall_to_wall_width() = enclosure_wall_to_wall_width;
 function get_enclosure_width() = enclosure_width;
 function get_flap_arc_separation() = (flap_hole_radius*2 + flap_hole_separation);
 function get_flap_gap() = flap_gap;
+function get_flap_pin_width() = flap_pin_width;
 function get_front_forward_offset() = front_forward_offset;
 function get_front_window_right_inset() = front_window_right_inset;
 function get_front_window_width() = front_window_width;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -178,12 +178,6 @@ enclosure_height_upper = exclusion_radius + enclosure_vertical_margin + thicknes
 enclosure_height_lower = flap_pitch_radius + flap_height + enclosure_vertical_margin + thickness + enclosure_vertical_inset;
 enclosure_height = enclosure_height_upper + enclosure_height_lower;
 
-function get_enclosure_width() = enclosure_width;
-function get_enclosure_height() = enclosure_height;
-function get_enclosure_height_lower() = enclosure_height_lower;
-function get_front_window_right_inset() = front_window_right_inset;
-function get_front_window_width() = front_window_width;
-
 enclosure_horizontal_rear_margin = thickness; // minumum distance between the farthest feature and the rear
 
 enclosure_length = front_forward_offset + 28byj48_mount_center_offset() + m4_hole_diameter/2 + enclosure_horizontal_rear_margin;
@@ -252,13 +246,17 @@ alignment_bar_center = (enclosure_length - enclosure_length_right) - alignment_b
 function get_captive_nut_inset() = captive_nut_inset;
 function get_connector_bracket_length() = connector_bracket_length_outer;
 function get_connector_bracket_width() = connector_bracket_width;
+function get_enclosure_height() = enclosure_height;
 function get_enclosure_height_lower() = enclosure_height_lower;
 function get_enclosure_length_right() = enclosure_length_right;
 function get_enclosure_vertical_inset() = enclosure_vertical_inset;
 function get_enclosure_wall_to_wall_width() = enclosure_wall_to_wall_width;
+function get_enclosure_width() = enclosure_width;
 function get_flap_arc_separation() = (flap_hole_radius*2 + flap_hole_separation);
 function get_flap_gap() = flap_gap;
 function get_front_forward_offset() = front_forward_offset;
+function get_front_window_right_inset() = front_window_right_inset;
+function get_front_window_width() = front_window_width;
 function get_magnet_diameter() = magnet_diameter;
 function get_magnet_hole_offset() = magnet_hole_offset;
 function get_mounting_hole_inset() = mounting_hole_inset;
@@ -465,17 +463,21 @@ module front_tabs_negative(upper, tool_diameter=undef) {
     for (i = [0 : num_front_tabs-1]) {
         translate([thickness + (i*2+0.5) * front_tab_width, cutout_offset, 0]) {
             square([front_tab_width + enclosure_tab_clearance, cutout_height + enclosure_tab_clearance], center=true);
-            translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                circle(d=tool_diameter_param, $fn=30);
-            }
-            translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                circle(d=tool_diameter_param, $fn=30);
-            }
-            translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                circle(d=tool_diameter_param, $fn=30);
-            }
-            translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                circle(d=tool_diameter_param, $fn=30);
+
+            // Dog-bones
+            if (!is_undef(tool_diameter)) {
+                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
+                    circle(d=tool_diameter_param, $fn=30);
+                }
+                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
+                    circle(d=tool_diameter_param, $fn=30);
+                }
+                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
+                    circle(d=tool_diameter_param, $fn=30);
+                }
+                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
+                    circle(d=tool_diameter_param, $fn=30);
+                }
             }
         }
     }

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -178,6 +178,12 @@ enclosure_height_upper = exclusion_radius + enclosure_vertical_margin + thicknes
 enclosure_height_lower = flap_pitch_radius + flap_height + enclosure_vertical_margin + thickness + enclosure_vertical_inset;
 enclosure_height = enclosure_height_upper + enclosure_height_lower;
 
+function get_enclosure_width() = enclosure_width;
+function get_enclosure_height() = enclosure_height;
+function get_enclosure_height_lower() = enclosure_height_lower;
+function get_front_window_right_inset() = front_window_right_inset;
+function get_front_window_width() = front_window_width;
+
 enclosure_horizontal_rear_margin = thickness; // minumum distance between the farthest feature and the rear
 
 enclosure_length = front_forward_offset + 28byj48_mount_center_offset() + m4_hole_diameter/2 + enclosure_horizontal_rear_margin;
@@ -482,24 +488,31 @@ module enclosure_etch_style() {
                 children();
 }
 
+module enclosure_front_base_2d() {
+    translate([-enclosure_horizontal_inset, 0, 0]) {
+        square([enclosure_width, enclosure_height]);
+    }
+}
+
+module enclosure_front_cutouts_2d() {
+    // Viewing window cutout
+    translate([front_window_right_inset, enclosure_height_lower - front_window_lower])
+        square([front_window_width, front_window_lower + front_window_upper]);
+
+    // Front lower tabs
+    translate([0, thickness * 0.5 + enclosure_vertical_inset, 0])
+        front_tabs_negative();
+
+    // Front upper tabs
+    translate([0, enclosure_height - thickness * 0.5 - enclosure_vertical_inset, 0])
+        front_tabs_negative();
+}
+
 module enclosure_front() {
     linear_extrude(height=thickness) {
         difference() {
-            translate([-enclosure_horizontal_inset, 0, 0]) {
-                square([enclosure_width, enclosure_height]);
-            }
-
-            // Viewing window cutout
-            translate([front_window_right_inset, enclosure_height_lower - front_window_lower])
-                square([front_window_width, front_window_lower + front_window_upper]);
-
-            // Front lower tabs
-            translate([0, thickness * 0.5 + enclosure_vertical_inset, 0])
-                front_tabs_negative();
-
-            // Front upper tabs
-            translate([0, enclosure_height - thickness * 0.5 - enclosure_vertical_inset, 0])
-                front_tabs_negative();
+            enclosure_front_base_2d();
+            enclosure_front_cutouts_2d();
         }
     }
 }


### PR DESCRIPTION
`combined_front_panel.scad` is a model for a configurable merged front panel. The frame width/height are configurable, as are the number of rows & columns of modules and the spacing between modules (can be defined as a "gap" value beyond the minimum possible module spacing, or a center-to-center distance).

There is a matching python script `generate_combined_front_panel.py` for exporting the design as an SVG, for use with a laser cutter or CAM tool.

Also adds some minimal support for routers/endmills with non-trivial kerf - only for the tabs on the front panel - which adds the option of dog bones for the corners and allows for using a tool that is larger than `thickness` while still keeping the vertical mounting position constrained.

Example model rendering for a large (4'x8') layout with 108 modules:
![combined_front_panel_example](https://user-images.githubusercontent.com/414890/124689025-a03be680-de8c-11eb-8ac4-bd20be76314a.png)
![combined_front_panel_example_closeup](https://user-images.githubusercontent.com/414890/124689028-a205aa00-de8c-11eb-9edc-4a0fd12f9914.png)

