### PR TITLE
Split Electronics GitHub Actions into separate jobs

### DIFF
--- a/.github/workflows/electronics.yml
+++ b/.github/workflows/electronics.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  export-electronics:
-    name: Export Electronics
+  export-electronics-classic:
+    name: Export Electronics (Classic + Sensor)
     runs-on: ubuntu-20.04
 
     steps:
@@ -105,6 +105,54 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
+      # Note: These kibot scripts are run last because they mess with file permissions which breaks other scripts, not sure why
+      - name: Export BOM [classic + sensors]
+        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
+        with:
+          config: electronics/splitflap.kibot.yml
+          dir: electronics/build
+          schema: 'electronics/splitflap.sch'
+          board: 'electronics/splitflap.kicad_pcb'
+
+      - name: Copy BOM outputs
+        run: cp -r electronics/build/bom electronics/build/outputs
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: electronics-classic
+          path: |
+            electronics/build
+
+      - name: Configure AWS Credentials
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync artifacts to S3
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        run: |
+          aws s3 sync electronics/build/outputs s3://splitflap-artifacts/${GITHUB_REF#refs/heads/}/electronics-classic --delete --acl public-read --cache-control max-age=0,no-cache
+
+
+  export-electronics-chainlink:
+    name: Export Electronics (Chainlink Driver)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up outputs directory
+        run: mkdir -p electronics/build/outputs
+
+      - name: Install dependencies
+        run: ./electronics/scripts/dependencies.sh
+
 # Chainlink Driver:
       - name: Export chainlinkDriver schematic
         run: |
@@ -142,6 +190,56 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
+      # Note: These kibot scripts are run last because they mess with file permissions which breaks other scripts, not sure why
+      - name: Export BOM [chainlinkDriver]
+        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
+        with:
+          config: electronics/chainlinkDriver/chainlinkDriver.kibot.yml
+          dir: electronics/build
+          schema: 'electronics/chainlinkDriver/chainlinkDriver.sch'
+          board: 'electronics/chainlinkDriver/chainlinkDriver.kicad_pcb'
+
+      - name: Copy BOM outputs
+        run: cp -r electronics/build/bom electronics/build/outputs
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: electronics-chainlink
+          path: |
+            electronics/build
+
+      - name: Configure AWS Credentials
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync artifacts to S3
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        run: |
+          aws s3 sync electronics/build/outputs s3://splitflap-artifacts/${GITHUB_REF#refs/heads/}/electronics-chainlink --delete --acl public-read --cache-control max-age=0,no-cache
+
+
+
+
+  export-electronics-chainlink-tester:
+    name: Export Electronics (Chainlink Driver Tester)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up outputs directory
+        run: mkdir -p electronics/build/outputs
+
+      - name: Install dependencies
+        run: ./electronics/scripts/dependencies.sh
+
 # Chainlink Driver Tester:
       - name: Export schematic [chainlinkDriverTester]
         run: |
@@ -178,6 +276,54 @@ jobs:
           ./scripts/annotate_image.sh electronics/build/outputs/chainlinkDriverTester-pcb-raster.png
         env:
           PYTHONUNBUFFERED: 1
+
+      # Note: These kibot scripts are run last because they mess with file permissions which breaks other scripts, not sure why
+      - name: Export BOM [chainlinkDriverTester]
+        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
+        with:
+          config: electronics/chainlinkDriverTester/chainlinkDriverTester.kibot.yml
+          dir: electronics/build
+          schema: 'electronics/chainlinkDriverTester/chainlinkDriverTester.sch'
+          board: 'electronics/chainlinkDriverTester/chainlinkDriverTester.kicad_pcb'
+
+      - name: Copy BOM outputs
+        run: cp -r electronics/build/bom electronics/build/outputs
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: electronics-chainlink-tester
+          path: |
+            electronics/build
+
+      - name: Configure AWS Credentials
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync artifacts to S3
+        if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
+        run: |
+          aws s3 sync electronics/build/outputs s3://splitflap-artifacts/${GITHUB_REF#refs/heads/}/electronics-chainlink-tester --delete --acl public-read --cache-control max-age=0,no-cache
+
+
+  export-electronics-chainlink-base:
+    name: Export Electronics (Chainlink Base)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up outputs directory
+        run: mkdir -p electronics/build/outputs
+
+      - name: Install dependencies
+        run: ./electronics/scripts/dependencies.sh
 
 # Chainlink Base:
       - name: Export schematic [chainlinkBase]
@@ -217,22 +363,6 @@ jobs:
           PYTHONUNBUFFERED: 1
 
       # Note: These kibot scripts are run last because they mess with file permissions which breaks other scripts, not sure why
-      - name: Export BOM [classic + sensors]
-        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
-        with:
-          config: electronics/splitflap.kibot.yml
-          dir: electronics/build
-          schema: 'electronics/splitflap.sch'
-          board: 'electronics/splitflap.kicad_pcb'
-
-      - name: Export BOM [chainlinkDriver]
-        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
-        with:
-          config: electronics/chainlinkDriver/chainlinkDriver.kibot.yml
-          dir: electronics/build
-          schema: 'electronics/chainlinkDriver/chainlinkDriver.sch'
-          board: 'electronics/chainlinkDriver/chainlinkDriver.kicad_pcb'
-
       - name: Export BOM [chainlinkBase]
         uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
         with:
@@ -241,23 +371,14 @@ jobs:
           schema: 'electronics/chainlinkBase/chainlinkBase.sch'
           board: 'electronics/chainlinkBase/chainlinkBase.kicad_pcb'
 
-      - name: Export BOM [chainlinkDriverTester]
-        uses: INTI-CMNB/KiBot@2ddbea3e681de09147cb1677890694857def32a8
-        with:
-          config: electronics/chainlinkDriverTester/chainlinkDriverTester.kibot.yml
-          dir: electronics/build
-          schema: 'electronics/chainlinkDriverTester/chainlinkDriverTester.sch'
-          board: 'electronics/chainlinkDriverTester/chainlinkDriverTester.kicad_pcb'
-
       - name: Copy BOM outputs
         run: cp -r electronics/build/bom electronics/build/outputs
-
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: electronics
+          name: electronics-chainlink-base
           path: |
             electronics/build
 
@@ -272,4 +393,4 @@ jobs:
       - name: Sync artifacts to S3
         if: github.event_name == 'push' && github.repository_owner == 'scottbez1'
         run: |
-          aws s3 sync electronics/build/outputs s3://splitflap-artifacts/${GITHUB_REF#refs/heads/}/electronics --delete --acl public-read --cache-control max-age=0,no-cache
+          aws s3 sync electronics/build/outputs s3://splitflap-artifacts/${GITHUB_REF#refs/heads/}/electronics-chainlink-base --delete --acl public-read --cache-control max-age=0,no-cache

--- a/README.md
+++ b/README.md
@@ -48,22 +48,22 @@ I'd love to hear your thoughts and questions about this project, and happy to in
     * For Ponoko 3mm acrylic ([svg](https://s3.amazonaws.com/splitflap-artifacts/master/3d/3d_laser_vector-ponoko-3mm-acrylic.svg))
     * For generic material (0.18mm kerf correction) ([svg](https://s3.amazonaws.com/splitflap-artifacts/master/3d/3d_laser_vector.svg))
 * Classic Controller electronics
-    * Bill of Materials ([csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/splitflap-bom.csv), [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/splitflap-ibom.html))
-    * PCB ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-pcb-packet.pdf))
-    * Panelized PCB ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-panelized-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-panelized-pcb-packet.pdf))
-* Sensor PCB, panelized ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/sensor-panelized-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/sensor-panelized-pcb-packet.pdf))
+    * Bill of Materials ([csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/bom/splitflap-bom.csv), [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/bom/splitflap-ibom.html))
+    * PCB ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-pcb-packet.pdf))
+    * Panelized PCB ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-panelized-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-panelized-pcb-packet.pdf))
+* Sensor PCB, panelized ([gerbers](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/sensor-panelized-jlc/gerbers.zip) / [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/sensor-panelized-pcb-packet.pdf))
 * Chainlink Driver PCB
-    * Schematic [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-schematic.pdf)
-    * PCB overview [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-pcb-packet.pdf)
-    * PCB gerbers [zip](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-jlc/gerbers.zip)
-    * PCB bom (for JLCPCB assembly) [csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-jlc/bom.csv)
-    * PCB CPL (for JLCPCB assembly) [csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-jlc/pos.csv)
-    * PCB bom (for manual assembly) [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/chainlinkDriver-ibom.html)
+    * Schematic [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-schematic.pdf)
+    * PCB overview [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-pcb-packet.pdf)
+    * PCB gerbers [zip](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-jlc/gerbers.zip)
+    * PCB bom (for JLCPCB assembly) [csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-jlc/bom.csv)
+    * PCB CPL (for JLCPCB assembly) [csv](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-jlc/pos.csv)
+    * PCB bom (for manual assembly) [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/bom/chainlinkDriver-ibom.html)
 * Chainlink Base PCB
-    * Schematic [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-schematic.pdf)
-    * PCB overview [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-pcb-packet.pdf)
-    * PCB gerbers [zip](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-jlc/gerbers.zip)
-    * PCB bom (for manual assembly) [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/chainlinkBase-ibom.html)
+    * Schematic [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-schematic.pdf)
+    * PCB overview [pdf](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-pcb-packet.pdf)
+    * PCB gerbers [zip](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-jlc/gerbers.zip)
+    * PCB bom (for manual assembly) [interactive](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/bom/chainlinkBase-ibom.html)
 If you are interested in building a display, I recommend using [one of the stable releases instead](https://github.com/scottbez1/splitflap/releases).
 
 ### Design Highlights
@@ -252,8 +252,8 @@ These boards are small (about 16mm x 16 mm) and the designs are available as a p
 apart. The panelization is configurable (see [generate_panelize_config.py](electronics/scripts/panelize/generate_panelize_config.py))
 and is optimized for production at SeeedStudio.
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/sensor-panelized-pcb-raster.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/sensor-panelized-pcb-raster.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/sensor-panelized-pcb-raster.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/sensor-panelized-pcb-raster.png"/>
 </a>
 
 
@@ -266,14 +266,14 @@ Nearly everything is a through-hole component rather than SMD, so it's very easy
 The driver uses 2 MIC5842 low-side shift-register drivers, with built-in transient-suppression diodes, to control the motors, and a 74HC165 shift register to read from 4 hall-effect magnetic home position sensors.
 There are optional WS2812B RGB LEDs which can be used to indicate the status of each of the 4 channels.
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-schematic.pdf">
-<img height="320" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-schematic.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-schematic.pdf">
+<img height="320" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-schematic.png"/>
 </a>
 
 The PCB layout is 10cm x 5cm which makes it fairly cheap to produce using a low-cost PCB manufacturer (e.g. Seeed Studio).
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-pcb-raster.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/classic-pcb-raster.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-pcb-raster.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-pcb-raster.png"/>
 </a>
 
 
@@ -293,8 +293,8 @@ power management/distribution, and sends data to the chained Driver boards. You 
 directly to one or more Chainlink Driver boards with no additional components (other than power supply).
 
 #### Chainlink Driver
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-3d.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-3d.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-3d.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-3d.png"/>
 </a>
 
 This is currently under active development. It has been tested and appears to work, but is not yet recommended for general use.
@@ -313,19 +313,19 @@ to validate data integrity up and down the whole chain
 * Module order goes from right-to-left since this is intended to be installed and accessed from *behind* the modules
 
 This design is optimized for assembly at JLCPCB, and files are automatically generated for ordering assembled PCBs there.
-However, if you wish to assemble this board yourself, you can view the [interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/chainlinkDriver-ibom.html)
+However, if you wish to assemble this board yourself, you can view the [interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/bom/chainlinkDriver-ibom.html)
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-schematic.pdf">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-schematic.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-schematic.pdf">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-schematic.png"/>
 </a>
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-pcb-raster.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriver-pcb-raster.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-pcb-raster.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink/chainlinkDriver-pcb-raster.png"/>
 </a>
 
 #### Chainlink Base
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-3d.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-3d.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-3d.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-3d.png"/>
 </a>
 
 This is currently under very active development. _It is **untested** and does not have firmware yet._
@@ -352,21 +352,21 @@ Key (planned) features:
   * Regulated 5V can be connected directly to the screw terminals, or
   * if you are using an always-on 12V PSU without a master relay, you can install a buck module and power the board from 12V using the 7-28V screw terminals
 
-[View the interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/chainlinkBase-ibom.html)
+[View the interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/bom/chainlinkBase-ibom.html)
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-schematic.pdf">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-schematic.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-schematic.pdf">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-schematic.png"/>
 </a>
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-pcb-raster.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkBase-pcb-raster.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-pcb-raster.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-base/chainlinkBase-pcb-raster.png"/>
 </a>
 
 ### Electrical tools
 
 #### Chainlink Driver Tester
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-3d.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-3d.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-3d.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-3d.png"/>
 </a>
 
 This is not likely to be useful unless you're assembling a _very_ large display, but the Chainlink Driver Tester is a complete testbed
@@ -385,14 +385,14 @@ Key (planned) features:
 * Large cutout allows a barcode scanner or camera to be aimed at the bottom of the board-under-test for tracking serial numbers.
 * Buzzer option for audible pass/fail feedback
 
-[View the interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics/bom/chainlinkDriverTester-ibom.html)
+[View the interactive BOM/placement tool](https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/bom/chainlinkDriverTester-ibom.html)
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-schematic.pdf">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-schematic.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-schematic.pdf">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-schematic.png"/>
 </a>
 
-<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-pcb-raster.png">
-<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics/chainlinkDriverTester-pcb-raster.png"/>
+<a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-pcb-raster.png">
+<img width="640" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-chainlink-tester/chainlinkDriverTester-pcb-raster.png"/>
 </a>
 
 ### Rendering

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,8 +74,8 @@
                 </p>
                 <iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/vq4o_88kN8g" frameborder="0" allowfullscreen></iframe>
                 <h1>Open source, up to date</h1>
-                <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/schematic.pdf">
-                    <img class="floater right_float" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/schematic.png" title="Driver schematic"/>
+                <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-schematic.pdf">
+                    <img class="floater right_float" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-schematic.png" title="Driver schematic"/>
                 </a>
                 <p>
                     All of the designs are <a href="https://github.com/scottbez1/splitflap/">open source</a>. The 3d
@@ -84,16 +84,16 @@
                 </p>
                 <p>
                     Most of the supporting materials, like the
-                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/schematic.pdf">schematic</a>,
-                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/bom.csv">bill of materials</a>,
-                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/pcb_gerber.zip">PCB gerbers</a>, and
+                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-schematic.pdf">schematic</a>,
+                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/splitflap-bom.csv">bill of materials</a>,
+                    <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-jlc/gerbers.zip">PCB gerbers</a>, and
                     even the interactive 3D rendering seen above are
                     <a href="https://scottbezek.blogspot.com/2016/04/automated-kicad-openscad-rendering.html">generated
                     automatically</a> as the design changes, using Github Actions. This way you can always see the latest
                     designs, even without having to check out the git repo or install any software yourself.
                 </p>
-                <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/pcb_raster.png">
-                    <img class="floater left_float" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-legacy/pcb_raster.png" title="Driver PCB design"/>
+                <a href="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-pcb-raster.png">
+                    <img class="floater left_float" src="https://s3.amazonaws.com/splitflap-artifacts/master/electronics-classic/classic-pcb-raster.png" title="Driver PCB design"/>
                 </a>
                 <p style="clear: right;">
                     I'd love to hear your thoughts and questions about this project, and happy to incorporate any
@@ -105,12 +105,12 @@
                 </p>
                 <h3>License</h3>
                 <p>
-                    The vast majority of this project is licensed under Apache v2 (see
+                    This project is licensed under Apache v2 (see
                     <a href="https://github.com/scottbez1/splitflap/blob/master/LICENSE.txt">LICENSE.txt</a> for full
                     details).
                 </p>
                 <pre>
-Copyright 2015-2018 Scott Bezek and the splitflap contributors
+Copyright 2015-2021 Scott Bezek and the splitflap contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Electronics action was starting to get a bit slow, mostly because of the 3d PCB rendering of 3 different PCBs (chainlinkDriver, chainlinkBase, and chainlinkDriverTester), so this splits that action into 3 separate jobs that can run in parallel. This requires separating the artifacts from each of the different electronics jobs, so all references had to be updated too.

Now the build duration is dominated by the environment setup and code checkout, which can be addressed separately.