### PR TITLE
Add a lot more rendering/design options for generate_2d.py 

### DIFF
--- a/3d/pcb.scad
+++ b/3d/pcb.scad
@@ -29,7 +29,7 @@ module pcb_outline_2d(hole=true) {
 }
 
 // 3D PCB module, origin at the center of the mounting hole on the bottom surface of the PCB
-module pcb(pcb_to_spool, render_jig=false) {
+module pcb(pcb_to_spool, render_jig=false, jig_thickness=0) {
     color([0, 0.5, 0]) {
         linear_extrude(height=pcb_thickness) {
             pcb_outline_2d();
@@ -86,7 +86,7 @@ module pcb(pcb_to_spool, render_jig=false) {
         color([1, 1, 0])
         translate([-pcb_edge_to_hole_x - pcb_jig_align_thickness - pcb_jig_align_clearance, pcb_hole_to_sensor_pin_1_y + pcb_sensor_pin_width/2 + thickness, -pcb_to_sensor(pcb_to_spool) + pcb_jig_depth_clearance])
         rotate([90, 0, 0])
-            sensor_jig(pcb_to_spool);
+            sensor_jig(pcb_to_spool, jig_thickness);
     }
 }
 
@@ -133,7 +133,7 @@ function pcb_thickness() = pcb_thickness;
 function sensor_jig_height(pcb_to_spool) = pcb_to_sensor(pcb_to_spool) - pcb_jig_depth_clearance + pcb_jig_align_length + pcb_thickness;
 function sensor_jig_width(pcb_to_spool) = pcb_length + (pcb_jig_align_thickness + pcb_jig_align_clearance) * 2;
 
-module sensor_jig(pcb_to_spool) {
+module sensor_jig(pcb_to_spool, thickness) {
     module fillet() {
         eps = 0.01;
         difference() {

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -68,11 +68,11 @@ if __name__ == '__main__':
     parser.add_argument('--no-front-panel', action='store_true', help='Do not include the front face of the enclosure, '
                                                                       'e.g. if you will use '
                                                                       'generate_combined_front_panel.py instead.')
-    parser.add_argument('--no-mounting-holes', action='store_true', help='Do not include mounting hole on top/botom '
+    parser.add_argument('--no-mounting-holes', action='store_true', help='Do not include mounting hole on top/bottom '
                                                                          'enclosure pieces.')
     parser.add_argument('--no-connectors', action='store_true', help='Do not include inter-module connector pieces.')
     parser.add_argument('--no-sensor-jig', action='store_true', help='Do not include the sensor spacing jig.')
-    parser.add_argument('--no-source-info', action='store_true', help='Do not include the source info - revision, date, url.')
+    parser.add_argument('--no-source-info', action='store_true', help='Do not include the source info: revision, date, url.')
     parser.add_argument('--zip-tie', choices=ZIP_TIE_MODES.keys(), default='STANDARD', help='Where to place zip-tie '
                                                                                             'holes for wire management.')
     parser.add_argument('--cut-home-indicator', action='store_true', help='Cut, instead of etch, the home position '

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -73,7 +73,8 @@ if __name__ == '__main__':
     parser.add_argument('--no-connectors', action='store_true', help='Do not include inter-module connector pieces.')
     parser.add_argument('--no-sensor-jig', action='store_true', help='Do not include the sensor spacing jig.')
     parser.add_argument('--no-source-info', action='store_true', help='Do not include the source info - revision, date, url.')
-    parser.add_argument('--zip-tie', choices=ZIP_TIE_MODES.keys(), help='Where to place zip-tie holes for wire management.')
+    parser.add_argument('--zip-tie', choices=ZIP_TIE_MODES.keys(), default='STANDARD', help='Where to place zip-tie '
+                                                                                            'holes for wire management.')
     parser.add_argument('--cut-home-indicator', action='store_true', help='Cut, instead of etch, the home position '
                                                                           'indicator on the spool.')
 

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -34,6 +34,12 @@ sys.path.append(repo_root)
 
 from util import rev_info
 
+ZIP_TIE_MODES = {
+    'NONE': 0,
+    'STANDARD': 1,
+    'UPDOWN': 2,
+}
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
@@ -58,6 +64,18 @@ if __name__ == '__main__':
                                                                       'Requires Inkscape and pdfjam. Implies '
                                                                       '--no-etch, --calculate-dimensions, and '
                                                                       '--skip-optimize')
+    parser.add_argument('--no-alignment-bar', action='store_true', help='Do not include features for the alignment bar')
+    parser.add_argument('--no-front-panel', action='store_true', help='Do not include the front face of the enclosure, '
+                                                                      'e.g. if you will use '
+                                                                      'generate_combined_front_panel.py instead.')
+    parser.add_argument('--no-mounting-holes', action='store_true', help='Do not include mounting hole on top/botom '
+                                                                         'enclosure pieces.')
+    parser.add_argument('--no-connectors', action='store_true', help='Do not include inter-module connector pieces.')
+    parser.add_argument('--no-sensor-jig', action='store_true', help='Do not include the sensor spacing jig.')
+    parser.add_argument('--no-source-info', action='store_true', help='Do not include the source info - revision, date, url.')
+    parser.add_argument('--zip-tie', choices=ZIP_TIE_MODES.keys(), help='Where to place zip-tie holes for wire management.')
+    parser.add_argument('--cut-home-indicator', action='store_true', help='Cut, instead of etch, the home position '
+                                                                          'indicator on the spool.')
 
     args = parser.parse_args()
     if args.render_elecrow:
@@ -72,6 +90,14 @@ if __name__ == '__main__':
         'render_date': rev_info.current_date(),
         'render_etch': not args.no_etch,
         'render_2d_mirror': args.mirror,
+        'enable_alignment_bar': not args.no_alignment_bar,
+        'render_front_panel': not args.no_front_panel,
+        'enable_mounting_holes': not args.no_mounting_holes,
+        'enable_connectors': not args.no_connectors,
+        'enable_sensor_jig': not args.no_sensor_jig,
+        'enable_source_info': not args.no_source_info,
+        'zip_tie_mode': ZIP_TIE_MODES[args.zip_tie],
+        'render_home_indicator_as_cut': args.cut_home_indicator,
     }
     if args.kerf is not None:
         extra_variables['kerf_width'] = args.kerf

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -59,7 +59,7 @@ enable_alignment_bar = true;
 enable_mounting_holes = true;
 enable_sensor_jig = true;
 enable_source_info = true;
-zip_tie_mode = 2; // 0=none; 1=standard; 2=up&down
+zip_tie_mode = 1; // 0=none; 1=standard; 2=up&down
 
 // Panelization:
 panel_vertical = 0;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -51,6 +51,15 @@ render_motor = true;
 render_index = -1;
 render_etch = false;
 render_2d_mirror = false;
+render_home_indicator_as_cut = false;
+render_front_panel = true;
+
+enable_connectors = true;
+enable_alignment_bar = true;
+enable_mounting_holes = true;
+enable_sensor_jig = true;
+enable_source_info = true;
+zip_tie_mode = 2; // 0=none; 1=standard; 2=up&down
 
 // Panelization:
 panel_vertical = 0;
@@ -414,10 +423,13 @@ module flap_spool_complete(captive_nut=false, motor_shaft=false, magnet_hole=fal
                 }
             }
             if (magnet_hole) {
-                // Hole for press fit magnet
-                translate([magnet_hole_offset, 0]) {
+                // Hole for press fit magnet, 90 degrees from home flap position
+                translate([0, magnet_hole_offset]) {
                     circle(r=magnet_hole_radius, $fn=15);
                 }
+            }
+            if (render_home_indicator_as_cut) {
+                flap_spool_home_indicator(num_flaps, flap_hole_radius, flap_hole_separation, flap_spool_outset, height=0);
             }
         }
     }
@@ -650,14 +662,16 @@ module enclosure_left() {
                 mirror([0, 1, 0])
                     side_tabs_negative(hole_sizes=[1]);
 
-            // Connector bracket cuts
-            translate([enclosure_height, enclosure_length]) {
-                mirror([1, 0, 0]) {
+            if (enable_connectors) {
+                // Connector bracket cuts
+                translate([enclosure_height, enclosure_length]) {
+                    mirror([1, 0, 0]) {
+                        connector_bracket_side_holes();
+                    }
+                }
+                translate([0, enclosure_length]) {
                     connector_bracket_side_holes();
                 }
-            }
-            translate([0, enclosure_length]) {
-                connector_bracket_side_holes();
             }
 
 
@@ -670,31 +684,45 @@ module enclosure_left() {
                 }
             }
 
-            // Zip tie holes, sensor (leading to bottom)
-            translate([enclosure_left_zip_bottom_inset, zip_tie_height/2 + enclosure_left_zip_side_inset, 0])
-                zip_tie_holes();
-
-            // Zip tie holes, motor (leading to top)
-            translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length - front_forward_offset])
-                rotate([0, 0, 90])  // cable channel facing 'up'
+            if (zip_tie_mode == 1) {
+                // Zip tie holes, sensor (leading to bottom)
+                translate([enclosure_left_zip_bottom_inset, zip_tie_height/2 + enclosure_left_zip_side_inset, 0])
                     zip_tie_holes();
 
-            // Alignment bar cutout
-            translate([0, alignment_bar_center]) {
-                union() {
-                    // Cutout
-                    translate([alignment_bar_cutout_width/2, 0])
-                        circle(r=alignment_bar_cutout_width/2, $fn=40);
-                    square([alignment_bar_cutout_width, alignment_bar_cutout_width], center=true);
+                // Zip tie holes, motor (leading to top)
+                translate([enclosure_height - enclosure_left_zip_top_inset, enclosure_length - front_forward_offset])
+                    rotate([0, 0, 90])  // cable channel facing 'up'
+                        zip_tie_holes();
+            } else if (zip_tie_mode == 2) {
+                // Zip tie holes, bottom
+                translate([10, zip_tie_spacing/2 + 5, 0])
+                    rotate([0, 0, 90])  // cable channel facing 'up/down'
+                        zip_tie_holes();
 
-                    // Front-side fillet
-                    // translate([0, alignment_bar_cutout_width/2, 0])
-                    //     fillet_tool(r=alignment_bar_fillet_radius, overlap=1, $fn=40);
+                // Zip tie holes, top
+                translate([enclosure_height - 10, zip_tie_spacing/2 + 5])
+                    rotate([0, 0, 90])  // cable channel facing 'up/down'
+                        zip_tie_holes();
+            }
 
-                    // Back-side fillet
-                    translate([0, -alignment_bar_cutout_width/2, 0])
-                        mirror([0, 1, 0])
-                            fillet_tool(r=alignment_bar_fillet_radius, $fn=40);
+            if (enable_alignment_bar) {
+                // Alignment bar cutout
+                translate([0, alignment_bar_center]) {
+                    union() {
+                        // Cutout
+                        translate([alignment_bar_cutout_width/2, 0])
+                            circle(r=alignment_bar_cutout_width/2, $fn=40);
+                        square([alignment_bar_cutout_width, alignment_bar_cutout_width], center=true);
+
+                        // Front-side fillet
+                        // translate([0, alignment_bar_cutout_width/2, 0])
+                        //     fillet_tool(r=alignment_bar_fillet_radius, overlap=1, $fn=40);
+
+                        // Back-side fillet
+                        translate([0, -alignment_bar_cutout_width/2, 0])
+                            mirror([0, 1, 0])
+                                fillet_tool(r=alignment_bar_fillet_radius, $fn=40);
+                    }
                 }
             }
         }
@@ -740,14 +768,16 @@ module enclosure_right() {
                 mirror([0, 1, 0])
                     side_tabs_negative(hole_sizes=[1]);
 
-            // Connector bracket cuts
-            translate([enclosure_height, enclosure_length_right]) {
-                mirror([1, 0, 0]) {
+            if (enable_connectors) {
+                // Connector bracket cuts
+                translate([enclosure_height, enclosure_length_right]) {
+                    mirror([1, 0, 0]) {
+                        connector_bracket_side_holes();
+                    }
+                }
+                translate([0, enclosure_length_right]) {
                     connector_bracket_side_holes();
                 }
-            }
-            translate([0, enclosure_length_right]) {
-                connector_bracket_side_holes();
             }
         }
     }
@@ -830,9 +860,11 @@ module enclosure_top() {
                     mirror([1, 0, 0])
                         side_captive_nuts(hole_types = [1]);
 
-                // mounting hole
-                translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, enclosure_length_right - mounting_hole_inset]) {
-                    circle(r=m4_hole_diameter/2, $fn=30);
+                if (enable_mounting_holes) {
+                    // mounting hole
+                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, enclosure_length_right - mounting_hole_inset]) {
+                        circle(r=m4_hole_diameter/2, $fn=30);
+                    }
                 }
             }
         }
@@ -878,9 +910,11 @@ module enclosure_bottom() {
                         mirror([1, 0, 0])
                             side_captive_nuts(hole_types = [1]);
 
-                // mounting hole
-                translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset]) {
-                    circle(r=m4_hole_diameter/2, $fn=30);
+                if (enable_mounting_holes) {
+                    // mounting hole
+                    translate([(enclosure_wall_to_wall_width - 2 * thickness)/2, mounting_hole_inset]) {
+                        circle(r=m4_hole_diameter/2, $fn=30);
+                    }
                 }
             }
         }
@@ -888,10 +922,12 @@ module enclosure_bottom() {
 }
 
 module enclosure_bottom_etch() {
-    enclosure_etch_style()
-        translate([captive_nut_inset + m4_nut_length + 1, 1, thickness]) {
-            text_label([str("rev. ", render_revision), render_date, "github.com/scottbez1/splitflap"]);
-        }
+    if (enable_source_info) {
+        enclosure_etch_style()
+            translate([captive_nut_inset + m4_nut_length + 1, 1, thickness]) {
+                text_label([str("rev. ", render_revision), render_date, "github.com/scottbez1/splitflap"]);
+            }
+    }
 }
 
 module split_flap_3d(front_flap_index, include_connector, include_front_panel=true) {
@@ -1241,14 +1277,18 @@ if (render_3d) {
                 translate([0, enclosure_length + kerf_width])
                     enclosure_right_etch();
 
-            translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
-                rotate([0, 0, -90])
-                    enclosure_front();
-
-            laser_etch()
+            if (render_front_panel) {
                 translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
                     rotate([0, 0, -90])
-                        enclosure_front_etch();
+                        enclosure_front();
+            }
+
+            if (render_front_panel) {
+                laser_etch()
+                    translate([0, enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - enclosure_horizontal_inset])
+                        rotate([0, 0, -90])
+                            enclosure_front_etch();
+            }
 
             // Top and bottom
             translate([enclosure_height + kerf_width + enclosure_length_right, enclosure_wall_to_wall_width + kerf_width])
@@ -1281,13 +1321,17 @@ if (render_3d) {
                 rotate([0, 0, 180])
                     spool_strut();
 
-            // Connector brackets on the top right
-            translate([enclosure_height + kerf_width, 2 * enclosure_wall_to_wall_width + 2 * kerf_width - thickness, 0])
-                connector_bracket();
-
-            translate([enclosure_height + kerf_width + connector_bracket_width - connector_bracket_length_outer, 2 * enclosure_wall_to_wall_width + 3 * kerf_width - thickness + connector_bracket_width + connector_bracket_length_outer, 0])
-                rotate([0,0,-90])
+            if (enable_connectors) {
+                // Connector brackets on the top right
+                translate([enclosure_height + kerf_width, 2 * enclosure_wall_to_wall_width + 2 * kerf_width - thickness, 0])
                     connector_bracket();
+            }
+
+            if (enable_connectors) {
+                translate([enclosure_height + kerf_width + connector_bracket_width - connector_bracket_length_outer, 2 * enclosure_wall_to_wall_width + 3 * kerf_width - thickness + connector_bracket_width + connector_bracket_length_outer, 0])
+                    rotate([0,0,-90])
+                        connector_bracket();
+            }
 
             // Flap spools in flap window
             flap_spool_y_off = enclosure_length + kerf_width + enclosure_length_right + kerf_width + enclosure_width - front_window_right_inset - enclosure_horizontal_inset - front_window_width/2;
@@ -1295,25 +1339,30 @@ if (render_3d) {
             translate([flap_spool_x_off, flap_spool_y_off])
                 flap_spool_complete(motor_shaft=true, magnet_hole=true);
             translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
-                flap_spool_complete(captive_nut=true);
+                mirror([0, 1, 0])
+                    flap_spool_complete(captive_nut=true);
 
             // Flap spool etching
-            laser_etch() {
-                translate([flap_spool_x_off, flap_spool_y_off])
-                    mirror([0, 1, 0])
-                    flap_spool_etch();
-                translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
-                    flap_spool_etch();
+            if (!render_home_indicator_as_cut) {
+                laser_etch() {
+                    translate([flap_spool_x_off, flap_spool_y_off])
+                        flap_spool_etch();
+                    translate([flap_spool_x_off + spool_outer_radius*2 + 2, flap_spool_y_off])
+                        mirror([0, 1, 0])
+                            flap_spool_etch();
+                }
             }
 
             // Spool retaining wall in motor window
             translate([enclosure_height_lower + 28byj48_shaft_offset() - 28byj48_chassis_radius() + (28byj48_chassis_radius() + motor_backpack_extent)/2, enclosure_length - front_forward_offset - 28byj48_chassis_radius() - motor_hole_slop/2 + spool_strut_width/2 + kerf_width])
                 spool_retaining_wall(m4_bolt_hole=true);
 
-            // Sensor soldering jig
-            translate([enclosure_height_lower + 28byj48_shaft_offset() - 28byj48_chassis_radius() + (28byj48_chassis_radius() + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius() + motor_hole_slop/2 - kerf_width])
-                rotate([0, 0, 180])
-                    sensor_jig(pcb_to_spool);
+            if (enable_sensor_jig) {
+                // Sensor soldering jig
+                translate([enclosure_height_lower + 28byj48_shaft_offset() - 28byj48_chassis_radius() + (28byj48_chassis_radius() + motor_backpack_extent)/2 + sensor_jig_width(pcb_to_spool)/2, enclosure_length - front_forward_offset + 28byj48_chassis_radius() + motor_hole_slop/2 - kerf_width])
+                    rotate([0, 0, 180])
+                        sensor_jig(pcb_to_spool, thickness);
+            }
         }
     }
 }

--- a/3d/spool.scad
+++ b/3d/spool.scad
@@ -42,15 +42,13 @@ module flap_spool_home_indicator(flaps, flap_hole_radius, flap_hole_separation, 
     outer_radius = flap_spool_outer_radius(flaps, flap_hole_radius, flap_hole_separation, outset);
 
     module flap_spool_home_indicator_2d() {
-        angle = (360 / flaps) * round(0.25 * flaps);  // always point directly to a flap hole
-
-        translate([cos(angle) * pitch_radius, sin(angle) * pitch_radius])
-        rotate([0, 0, angle])
-        translate([-flap_hole_radius * 2, 0])
-        hull() {
-            circle(r=flap_hole_radius/2, $fn=30);
-            translate([-flap_hole_radius * 1.25, 0])
-            circle(r=flap_hole_radius/2, $fn=30);
+        translate([pitch_radius -flap_hole_radius * 3, 0]) {
+            hull() {
+                circle(r=flap_hole_radius/2, $fn=30);
+                translate([-flap_hole_radius * 1.25, 0]) {
+                    circle(r=flap_hole_radius/2, $fn=30);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
New options:
```
  --no-alignment-bar    Do not include features for the alignment bar
  --no-front-panel      Do not include the front face of the enclosure, e.g. if you will use
                        generate_combined_front_panel.py instead.
  --no-mounting-holes   Do not include mounting hole on top/bottom enclosure pieces.
  --no-connectors       Do not include inter-module connector pieces.
  --no-sensor-jig       Do not include the sensor spacing jig.
  --no-source-info      Do not include the source info: revision, date, url.
  --zip-tie {NONE,STANDARD,UPDOWN}
                        Where to place zip-tie holes for wire management.
  --cut-home-indicator  Cut, instead of etch, the home position indicator on the spool.
```

Also fixes a warning from undefined `thickness` in `pcb.scad`