### PR TITLE
Front panel generation improvements

### DIFF
--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -56,6 +56,9 @@ display_text = [
 // Number of full modules, rather than just flaps, to render in 3d
 render_full_modules_count = 4;
 
+
+center_window = false;
+
 // ---------------------------
 // End configurable parameters
 // ---------------------------
@@ -72,8 +75,10 @@ assert(is_undef(gap_y) || gap_y >= 0);
 layout_center_center_x = is_undef(center_center_x) ? get_enclosure_width() + gap_x : center_center_x;
 layout_center_center_y = is_undef(center_center_y) ? get_enclosure_height() + gap_y : center_center_y;
 
+y_offset = center_window ? get_front_window_lower() - (get_front_window_upper() + get_front_window_lower())/2 : 0;
+
 module centered_front() {
-    translate([-get_front_window_right_inset() - get_front_window_width()/2, -get_enclosure_height_lower()]) {
+    translate([-get_front_window_right_inset() - get_front_window_width()/2, -get_enclosure_height_lower() + y_offset]) {
         children();
     }
 }
@@ -105,25 +110,26 @@ projection_renderer(render_index = render_index, render_etch = render_etch, kerf
     }
 }
 
-%
-for (i=[0:cols-1]) {
-    for (j=[0:rows-1]) {
-        index = i + j*cols;
-        translate([i * layout_center_center_x, -j * layout_center_center_y]) {
-            if (index < render_full_modules_count) {
-                translate([get_front_window_right_inset() + get_front_window_width()/2, 0, -get_front_forward_offset()]) {
-                    rotate([90, 0, 180]) {
-                        split_flap_3d(get_flap_index_for_letter(display_text[j][i]), false, false);
+if (!is_projection_rendering()) {
+    for (i=[0:cols-1]) {
+        for (j=[0:rows-1]) {
+            index = i + j*cols;
+            translate([i * layout_center_center_x, -j * layout_center_center_y]) {
+                if (index < render_full_modules_count) {
+                    translate([get_front_window_right_inset() + get_front_window_width()/2, y_offset, -get_front_forward_offset()]) {
+                        rotate([90, 0, 180]) {
+                            split_flap_3d(get_flap_index_for_letter(display_text[j][i]), false, false);
+                        }
                     }
-                }
-            } else {
-                // Render just a flap
-                translate([-flap_width/2, 0]) {
-                    flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i]), get_flap_gap());
-                }
-                translate([-flap_width/2, -(get_flap_gap() + get_flap_pin_width())]) {
-                    rotate([-180, 0, 0]) {
-                        flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i])-1, get_flap_gap());
+                } else {
+                    // Render just a flap
+                    translate([-flap_width/2, 0]) {
+                        flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i]), get_flap_gap());
+                    }
+                    translate([-flap_width/2, -(get_flap_gap() + get_flap_pin_width())]) {
+                        rotate([-180, 0, 0]) {
+                            flap_with_letters(flap_color, letter_color, get_flap_index_for_letter(display_text[j][i])-1, get_flap_gap());
+                        }
                     }
                 }
             }

--- a/3d/scripts/generate_combined_front_panel.py
+++ b/3d/scripts/generate_combined_front_panel.py
@@ -57,10 +57,13 @@ if __name__ == '__main__':
     y_group.add_argument('--spacing-y', type=float, help='Vertical gap between modules')
     y_group.add_argument('--center-center-y', type=float, help='Vertical center-to-center distance between modules')
 
-    width = parser.add_argument('--width', type=float, help='Width of the panel')
-    height = parser.add_argument('--height', type=float, help='Height of the panel')
+    parser.add_argument('--width', type=float, help='Width of the panel')
+    parser.add_argument('--height', type=float, help='Height of the panel')
 
-    tool_diameter = parser.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
+    parser.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
+    parser.add_argument('--center-window', action='store_true', help='Vertically center the window instead of the '
+                                                                     'default of vertically centering the front '
+                                                                     'flap/letter.')
 
     args = parser.parse_args()
 
@@ -82,9 +85,9 @@ if __name__ == '__main__':
     if args.spacing_y is not None:
         extra_variables['gap_y'] = args.spacing_y
     if args.center_center_x is not None:
-        extra_variables['center_center_x'] = center_center_x
+        extra_variables['center_center_x'] = args.center_center_x
     if args.center_center_y is not None:
-        extra_variables['center_center_y'] = center_center_y
+        extra_variables['center_center_y'] = args.center_center_y
 
     if args.width is not None:
         extra_variables['frame_width'] = args.width
@@ -93,6 +96,8 @@ if __name__ == '__main__':
 
     if args.tool_diameter is not None:
         extra_variables['tool_diameter'] = args.tool_diameter
+
+    extra_variables['center_window'] = args.center_window
 
     output_dir = os.path.join(source_parts_dir, 'build', 'front_panel')
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -267,7 +267,9 @@ function get_flap_color() = flap_color;
 function get_flap_gap() = flap_gap;
 function get_flap_pin_width() = flap_pin_width;
 function get_front_forward_offset() = front_forward_offset;
+function get_front_window_lower() = front_window_lower;
 function get_front_window_right_inset() = front_window_right_inset;
+function get_front_window_upper() = front_window_upper;
 function get_front_window_width() = front_window_width;
 function get_letter_color() = letter_color;
 function get_magnet_diameter() = magnet_diameter;
@@ -482,24 +484,29 @@ module front_tabs_negative(upper, tool_diameter=undef) {
 
             // Dog-bones
             if (!is_undef(tool_diameter)) {
+                // Dog-bones are rendered as squares to simplify the number of lines in the final SVG output
                 translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                    circle(d=tool_diameter_param, $fn=30);
+                    square([tool_diameter_param, tool_diameter_param], center=true);
                 }
                 translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                    circle(d=tool_diameter_param, $fn=30);
+                    square([tool_diameter_param, tool_diameter_param], center=true);
                 }
                 translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                    circle(d=tool_diameter_param, $fn=30);
+                    square([tool_diameter_param, tool_diameter_param], center=true);
                 }
                 translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                    circle(d=tool_diameter_param, $fn=30);
+                    square([tool_diameter_param, tool_diameter_param], center=true);
                 }
             }
         }
     }
     for (i = [0 : num_front_tabs-2]) {
         translate([thickness + (i*2+1.5) * front_tab_width, 0, 0]) {
-            circle(r=m4_hole_diameter/2, $fn=30);
+            if (is_undef(tool_diameter)) {
+                circle(r=m4_hole_diameter/2, $fn=30);
+            } else {
+                square([m4_hole_diameter, m4_hole_diameter], center=true);
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `--center-window` option to vertically center the modules based on their window, rather than the default of centering based on flap/letter centers
- Improve export performance drastically by omitting the 3d splitflap modules entire in projection rendering mode
- Fix `--center-center-x` and `--center-center-y` arguments
- Change dog bone shape (and front face M4 hole) to rectangles to simplify the 2d geometry that's exported for external CAM (Fusion 360 did not perform well with all of the polygon-ized cricles)