### PR TITLE
Front panel improvements

### DIFF
--- a/3d/scripts/generate_combined_front_panel.py
+++ b/3d/scripts/generate_combined_front_panel.py
@@ -31,6 +31,12 @@ source_parts_dir = os.path.dirname(script_dir)
 repo_root = os.path.dirname(source_parts_dir)
 sys.path.append(repo_root)
 
+CENTER_MODES = {
+    'letter': 0,
+    'window': 1,
+    'module': 2,
+}
+
 def render(extra_variables, output_directory):
     renderer = Renderer(os.path.join(source_parts_dir, 'combined_front_panel.scad'), output_directory, extra_variables)
     renderer.clean()
@@ -42,9 +48,10 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser("")
 
-    kerf_group = parser.add_mutually_exclusive_group()
-    kerf_group.add_argument('--kerf', type=float, help='Override kerf_width value')
+    kerf_group = parser.add_mutually_exclusive_group(required=True)
+    kerf_group.add_argument('--kerf', type=float, help='Set kerf_width value')
     kerf_group.add_argument('--kerf-preset', choices=KERF_PRESETS, help='Override kerf_width using a defined preset')
+    kerf_group.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
 
     parser.add_argument('--rows', type=int, help='Number of rows')
     parser.add_argument('--cols', type=int, help='Number of columns')
@@ -57,13 +64,15 @@ if __name__ == '__main__':
     y_group.add_argument('--spacing-y', type=float, help='Vertical gap between modules')
     y_group.add_argument('--center-center-y', type=float, help='Vertical center-to-center distance between modules')
 
-    parser.add_argument('--width', type=float, help='Width of the panel')
-    parser.add_argument('--height', type=float, help='Height of the panel')
+    width_group = parser.add_mutually_exclusive_group()
+    width_group.add_argument('--width', type=float, help='Width of the panel')
+    width_group.add_argument('--frame-margin-x', type=float, help='Margin to add to the left and right sides')
 
-    parser.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
-    parser.add_argument('--center-window', action='store_true', help='Vertically center the window instead of the '
-                                                                     'default of vertically centering the front '
-                                                                     'flap/letter.')
+    height_group = parser.add_mutually_exclusive_group()
+    height_group.add_argument('--height', type=float, help='Height of the panel')
+    height_group.add_argument('--frame-margin-y', type=float, help='Margin to add to the top and bottom')
+
+    parser.add_argument('--center-mode', choices=CENTER_MODES, help='Specify how modules should be centered')
 
     args = parser.parse_args()
 
@@ -94,10 +103,15 @@ if __name__ == '__main__':
     if args.height is not None:
         extra_variables['frame_height'] = args.height
 
+    if args.frame_margin_x is not None:
+        extra_variables['frame_margin_x'] = args.frame_margin_x
+    if args.frame_margin_y is not None:
+        extra_variables['frame_margin_y'] = args.frame_margin_y
+
     if args.tool_diameter is not None:
         extra_variables['tool_diameter'] = args.tool_diameter
 
-    extra_variables['center_window'] = args.center_window
+    extra_variables['center_mode'] = CENTER_MODES[args.center_mode]
 
     output_dir = os.path.join(source_parts_dir, 'build', 'front_panel')
 

--- a/3d/scripts/generate_combined_front_panel.py
+++ b/3d/scripts/generate_combined_front_panel.py
@@ -50,29 +50,29 @@ if __name__ == '__main__':
 
     kerf_group = parser.add_mutually_exclusive_group(required=True)
     kerf_group.add_argument('--kerf', type=float, help='Set kerf_width value')
-    kerf_group.add_argument('--kerf-preset', choices=KERF_PRESETS, help='Override kerf_width using a defined preset')
+    kerf_group.add_argument('--kerf-preset', choices=KERF_PRESETS, help='Set kerf_width using a defined preset')
     kerf_group.add_argument('--tool-diameter', type=float, help='Diameter of cutting tool')
 
-    parser.add_argument('--rows', type=int, help='Number of rows')
-    parser.add_argument('--cols', type=int, help='Number of columns')
+    parser.add_argument('--rows', type=int, required=True, help='Number of rows')
+    parser.add_argument('--cols', type=int, required=True, help='Number of columns')
 
-    x_group = parser.add_mutually_exclusive_group()
+    x_group = parser.add_mutually_exclusive_group(required=True)
     x_group.add_argument('--spacing-x', type=float, help='Horizontal gap between modules')
     x_group.add_argument('--center-center-x', type=float, help='Horizontal center-to-center distance between modules')
 
-    y_group = parser.add_mutually_exclusive_group()
+    y_group = parser.add_mutually_exclusive_group(required=True)
     y_group.add_argument('--spacing-y', type=float, help='Vertical gap between modules')
     y_group.add_argument('--center-center-y', type=float, help='Vertical center-to-center distance between modules')
 
-    width_group = parser.add_mutually_exclusive_group()
+    width_group = parser.add_mutually_exclusive_group(required=True)
     width_group.add_argument('--width', type=float, help='Width of the panel')
     width_group.add_argument('--frame-margin-x', type=float, help='Margin to add to the left and right sides')
 
-    height_group = parser.add_mutually_exclusive_group()
+    height_group = parser.add_mutually_exclusive_group(required=True)
     height_group.add_argument('--height', type=float, help='Height of the panel')
     height_group.add_argument('--frame-margin-y', type=float, help='Margin to add to the top and bottom')
 
-    parser.add_argument('--center-mode', choices=CENTER_MODES, help='Specify how modules should be centered')
+    parser.add_argument('--center-mode', choices=CENTER_MODES, required=True, help='Specify how modules should be centered')
 
     args = parser.parse_args()
 
@@ -83,11 +83,11 @@ if __name__ == '__main__':
         extra_variables['kerf_width'] = args.kerf
     elif args.kerf_preset is not None:
         extra_variables['kerf_width'] = KERF_PRESETS[args.kerf_preset]
+    elif args.tool_diameter is not None:
+        extra_variables['tool_diameter'] = args.tool_diameter
 
-    if args.rows is not None:
-        extra_variables['rows'] = args.rows
-    if args.cols is not None:
-        extra_variables['cols'] = args.cols
+    extra_variables['rows'] = args.rows
+    extra_variables['cols'] = args.cols
 
     if args.spacing_x is not None:
         extra_variables['gap_x'] = args.spacing_x
@@ -107,9 +107,6 @@ if __name__ == '__main__':
         extra_variables['frame_margin_x'] = args.frame_margin_x
     if args.frame_margin_y is not None:
         extra_variables['frame_margin_y'] = args.frame_margin_y
-
-    if args.tool_diameter is not None:
-        extra_variables['tool_diameter'] = args.tool_diameter
 
     extra_variables['center_mode'] = CENTER_MODES[args.center_mode]
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -465,15 +465,14 @@ module motor_shaft() {
     }
 }
 
-module front_tabs_negative(upper, tool_diameter=undef) {
+module front_tabs_negative(upper, tool_diameter=0) {
     // tool_diameter is an optional parameter to adjust these cutouts to compensate for a rotary cutting tool, which
     // requires "dog-bones" for corners and adjustment of the cutout if the tool is larger than thickness. This will
     // generally not look good if cut all the way through the material, but with a CNC router these can be cut as
     // pockets which are not visible from the front.
-    tool_diameter_param = is_undef(tool_diameter) ? 0 : tool_diameter;
-    assert(tool_diameter_param <= m4_hole_diameter, "Tool diameter is too large to cut M4 holes");
+    assert(tool_diameter <= m4_hole_diameter, "Tool diameter is too large to cut M4 holes");
 
-    cutout_height = max(thickness, tool_diameter_param);
+    cutout_height = max(thickness, tool_diameter);
 
     // Offset is inverted on upper vs lower so that larger cutouts from tool diameter don't allow vertical movement freedom
     cutout_offset = (upper ? 1 : -1) * (cutout_height - thickness)/2;
@@ -483,26 +482,26 @@ module front_tabs_negative(upper, tool_diameter=undef) {
             square([front_tab_width + enclosure_tab_clearance, cutout_height + enclosure_tab_clearance], center=true);
 
             // Dog-bones
-            if (!is_undef(tool_diameter)) {
-                // Dog-bones are rendered as squares to simplify the number of lines in the final SVG output
-                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                    square([tool_diameter_param, tool_diameter_param], center=true);
+            if (tool_diameter > 0) {
+                // Dog-bones are rendered as squares to simplify the number of line segments in the final SVG output
+                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter/2, (cutout_height + enclosure_tab_clearance)/2]) {
+                    square([tool_diameter, tool_diameter], center=true);
                 }
-                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                    square([tool_diameter_param, tool_diameter_param], center=true);
+                translate([(front_tab_width + enclosure_tab_clearance)/2 - tool_diameter/2, -(cutout_height + enclosure_tab_clearance)/2]) {
+                    square([tool_diameter, tool_diameter], center=true);
                 }
-                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, (cutout_height + enclosure_tab_clearance)/2]) {
-                    square([tool_diameter_param, tool_diameter_param], center=true);
+                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter/2, (cutout_height + enclosure_tab_clearance)/2]) {
+                    square([tool_diameter, tool_diameter], center=true);
                 }
-                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter_param/2, -(cutout_height + enclosure_tab_clearance)/2]) {
-                    square([tool_diameter_param, tool_diameter_param], center=true);
+                translate([-(front_tab_width + enclosure_tab_clearance)/2 + tool_diameter/2, -(cutout_height + enclosure_tab_clearance)/2]) {
+                    square([tool_diameter, tool_diameter], center=true);
                 }
             }
         }
     }
     for (i = [0 : num_front_tabs-2]) {
         translate([thickness + (i*2+1.5) * front_tab_width, 0, 0]) {
-            if (is_undef(tool_diameter)) {
+            if (tool_diameter == 0) {
                 circle(r=m4_hole_diameter/2, $fn=30);
             } else {
                 square([m4_hole_diameter, m4_hole_diameter], center=true);
@@ -545,7 +544,7 @@ module enclosure_front_base_2d() {
     }
 }
 
-module enclosure_front_cutouts_2d(tool_diameter=undef) {
+module enclosure_front_cutouts_2d(tool_diameter=0) {
     // Viewing window cutout
     translate([front_window_right_inset, enclosure_height_lower - front_window_lower])
         square([front_window_width, front_window_lower + front_window_upper]);


### PR DESCRIPTION
- Add frame margin mode (to size frame based on module size)
- Add module vertical centering mode
- Minor improvements to make it easier to export front panels directly from OpenSCAD

## Examples
### 1x4 minimum frame size and spacing, to be laser-cut from Ponoko 3mm MDF
```
./3d/scripts/generate_combined_front_panel.py --rows 1 --cols 4 --frame-margin-x 0 --frame-margin-y 0 --spacing-x 0 --spacing-y 0 --center-mode module --kerf-preset ponoko-3mm-mdf
```

### 6x18 layout on a 4 foot x 8 foot panel with 4 inch o.c. horizontal and 7.25 inch o.c. vertical, to be CNC routed using a 1/8" end mill
```
./3d/scripts/generate_combined_front_panel.py --rows 6 --cols 18 --width 2438.4 --height 1219.2 --center-center-x 101.6 --center-center-y 184.15 --center-mode window --tool-diameter 3.5
```