### PR TITLE
Tweak fit parameters; add Elecrow acrylic kerf value

### DIFF
--- a/3d/scripts/kerf_presets.py
+++ b/3d/scripts/kerf_presets.py
@@ -3,4 +3,5 @@ KERF_PRESETS = {
     'ponoko-3mm-mdf': 0.18,
     'ponoko-3mm-acrylic': 0.1,
     'elecrow-3mm-wood': 0.185,
+    'elecrow-3mm-acrylic': 0.1,
 }

--- a/3d/sensor_pcb_dimensions.scad
+++ b/3d/sensor_pcb_dimensions.scad
@@ -59,7 +59,7 @@ pcb_connector_height = 3.2;
 pcb_connector_width = 8.2;
 pcb_connector_length = 18;
 pcb_connector_pin_width = 0.64;
-pcb_connector_pin_slop = 0.1;
+pcb_connector_pin_slop = 0.4;
 pcb_connector_pin_tail_length = 3.05 + 2.5/2;
 
 pcb_sensor_pin_width = 0.43;

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -166,7 +166,7 @@ magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
 // Clearance between the motor chassis and the outside right wall of the previous module
 28byj48_chassis_height_clearance = 1.4;
 
-motor_shaft_under_radius = 0.05;  // interference fit
+motor_shaft_under_radius = 0.08;  // interference fit
 motor_slop_radius = 3;
 
 

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -120,7 +120,7 @@ flap_width_slop = 0.5;  // amount of slop of the flap side to side between the 2
 
 spool_width_slop = 1.4;  // amount of slop for the spool assembly side-to-side inside the enclosure
 
-spool_tab_clearance = -0.06;  // for the tabs connecting the struts to the spool ends (interference fit)
+spool_tab_clearance = 0;  // for the tabs connecting the struts to the spool ends (interference fit)
 spool_retaining_clearance = 0.10;  // for the notches in the spool retaining wall
 spool_joint_clearance = 0.10;  // for the notched joints on the spool struts
 
@@ -156,16 +156,17 @@ spool_strut_inner_length = spool_width - 3 * thickness;
 
 spool_strut_exclusion_radius = sqrt((spool_strut_tab_outset+thickness/2)*(spool_strut_tab_outset+thickness/2) + (spool_strut_tab_width/2)*(spool_strut_tab_width/2));
 
+m4_axle_hole_diameter = 4.3;    // Slightly closer fit than the standard m4_hole_diameter, since a loose fit here will cause the spool to sit at a slight angle
 
 magnet_diameter = 4;
-magnet_hole_clearance = -0.07;  // interference fit
+magnet_hole_clearance = -0.05;  // interference fit
 magnet_hole_radius = (magnet_diameter + magnet_hole_clearance)/2;
 magnet_hole_offset = (spool_strut_exclusion_radius + flap_pitch_radius)/2;
 
 // Clearance between the motor chassis and the outside right wall of the previous module
 28byj48_chassis_height_clearance = 1.4;
 
-motor_shaft_under_radius = 0.08;  // interference fit
+motor_shaft_under_radius = 0.05;  // interference fit
 motor_slop_radius = 3;
 
 
@@ -757,7 +758,7 @@ module enclosure_right() {
         difference() {
             square([enclosure_height, enclosure_length_right]);
             translate([enclosure_height_upper, enclosure_length_right - front_forward_offset, 0])
-                circle(r=m4_hole_diameter/2, $fn=30);
+                circle(r=m4_axle_hole_diameter/2, $fn=30);
 
             // backstop bolt slot
             translate([enclosure_height_upper - backstop_bolt_vertical_offset, enclosure_length_right - front_forward_offset, 0]) {


### PR DESCRIPTION
- increase clearance for PCB connector pins (slot width)
- remove spool tab interference (kerf value isn't accurate enough anyway, and undersizing requires labor-intensive filing/sanding whereas oversizing just requires a little glue)
- shrink spool axle M4 hole to get less spool "sag" due to unnecessary clearance
- decrease interference on magnet hole (again, an undersized hole is labor intensive to fix whereas oversized just requires a dot of glue in the worst case)
- add Elecrow acrylic kerf value that has been tested