### PR TITLE
Log some useful values when generating combined front panels

### DIFF
--- a/3d/combined_front_panel.scad
+++ b/3d/combined_front_panel.scad
@@ -85,6 +85,9 @@ assert(is_undef(gap_y) || gap_y >= 0);
 layout_center_center_x = is_undef(center_center_x) ? get_enclosure_width() + gap_x : center_center_x;
 layout_center_center_y = is_undef(center_center_y) ? get_enclosure_height() + gap_y : center_center_y;
 
+echo(debug_gap_x = layout_center_center_x - get_enclosure_width());
+echo(debug_gap_y = layout_center_center_y - get_enclosure_height());
+
 layout_frame_width = is_undef(frame_margin_x) ? frame_width : layout_center_center_x * (cols - 1) + get_enclosure_width() + frame_margin_x*2;
 layout_frame_height = is_undef(frame_margin_y) ? frame_height : layout_center_center_y * (rows - 1) + get_enclosure_height() + frame_margin_y*2;
 
@@ -92,6 +95,9 @@ y_offset = center_mode == 0 ? 0 :
             center_mode == 1 ? get_front_window_lower() - (get_front_window_upper() + get_front_window_lower())/2 :
             center_mode == 2 ? get_enclosure_height_lower() - get_enclosure_height()/2:
             0;
+
+echo(debug_frame_margin_top = (layout_frame_height - layout_center_center_y * (rows - 1))/2 - get_enclosure_height_upper() - y_offset);
+echo(debug_frame_margin_bottom = (layout_frame_height - layout_center_center_y * (rows - 1))/2 - get_enclosure_height_lower() + y_offset);
 
 module centered_front() {
     translate([-get_front_window_right_inset() - get_front_window_width()/2, -get_enclosure_height_lower() + y_offset]) {

--- a/3d/scripts/projection_renderer.py
+++ b/3d/scripts/projection_renderer.py
@@ -55,7 +55,11 @@ class Renderer(object):
             }),
             capture_output=True,
         )
-        return openscad.extract_values(stderr)['num_components']
+        outputs = openscad.extract_values(stderr)
+        for key, value in outputs.items():
+            if key.startswith('debug_'):
+                logging.debug('DEBUG VALUE %r = %r', key, value)
+        return outputs['num_components']
 
     def _get_component_file(self, i):
         return os.path.join(self.output_folder, 'component_%05d.svg' % i)

--- a/3d/splitflap.scad
+++ b/3d/splitflap.scad
@@ -259,6 +259,7 @@ function get_connector_bracket_length() = connector_bracket_length_outer;
 function get_connector_bracket_width() = connector_bracket_width;
 function get_enclosure_height() = enclosure_height;
 function get_enclosure_height_lower() = enclosure_height_lower;
+function get_enclosure_height_upper() = enclosure_height_upper;
 function get_enclosure_length_right() = enclosure_length_right;
 function get_enclosure_vertical_inset() = enclosure_vertical_inset;
 function get_enclosure_wall_to_wall_width() = enclosure_wall_to_wall_width;


### PR DESCRIPTION
- Add support for printing debug values from OpenSCAD as part of the projection-renderer process
- Print the calculated X and Y gaps between modules
- Print the top and bottom frame margins (distance between top/bottom of module and edge of frame)