### PR TITLE
Add basic Windows and Mac OS support to 3d scripts, support Inkscape 1.0

### DIFF
--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -32,7 +32,11 @@ source_parts_dir = os.path.dirname(script_dir)
 repo_root = os.path.dirname(source_parts_dir)
 sys.path.append(repo_root)
 
-from util import rev_info
+from util import (
+    app_paths,
+    inkscape,
+    rev_info,
+)
 
 ZIP_TIE_MODES = {
     'NONE': 0,
@@ -129,15 +133,15 @@ if __name__ == '__main__':
         processor.write(svg_for_dimensions)
         logging.info('Read dimensions')
         width_px = float(subprocess.check_output([
-            'inkscape',
-            '--without-gui',
+            app_paths.get('inkscape'),
+        ] + inkscape.without_gui() + [
             '--query-width',
             svg_for_dimensions,
         ]))
         width_mm = width_px * 25.4 / 96 # Assuming 96dpi...
         height_px = float(subprocess.check_output([
-            'inkscape',
-            '--without-gui',
+            app_paths.get('inkscape'),
+        ] + inkscape.without_gui() + [
             '--query-height',
             svg_for_dimensions,
         ]))
@@ -158,7 +162,7 @@ if __name__ == '__main__':
 
         logging.info('Resize SVG canvas')
         subprocess.check_call([
-            'inkscape',
+            app_paths.get('inkscape'),
             '--verb=FitCanvasToDrawing',
             '--verb=FileSave',
             '--verb=FileClose',
@@ -168,15 +172,13 @@ if __name__ == '__main__':
 
         logging.info('Output PDF')
         subprocess.check_call([
-            'inkscape',
+            app_paths.get('inkscape'),
             elecrow_svg,
-            '--export-pdf',
-            elecrow_intermediate_pdf,
-        ])
+        ] + inkscape.export_pdf(elecrow_intermediate_pdf))
 
         logging.info('Resize PDF')
         subprocess.check_call([
-            'pdfjam',
+            app_paths.get('pdfjam'),
             '--letterpaper',
             '--landscape',
             '--noautoscale',
@@ -206,7 +208,7 @@ if __name__ == '__main__':
 
         logging.info('Resize SVG canvas')
         subprocess.check_call([
-            'inkscape',
+            app_paths.get('inkscape'),
             '--verb=FitCanvasToDrawing',
             '--verb=FileSave',
             '--verb=FileClose',
@@ -216,9 +218,9 @@ if __name__ == '__main__':
 
         logging.info('Export PNG')
         subprocess.check_call([
-            'inkscape',
+            app_paths.get('inkscape'),
             '--export-width=320',
-            '--export-png', raster_png,
+        ] + inkscape.export_png(raster_png) + [
             raster_svg,
         ])
 

--- a/3d/scripts/generate_fonts.py
+++ b/3d/scripts/generate_fonts.py
@@ -57,9 +57,9 @@ def render(extra_variables, skip_optimize, output_directory):
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
-    parser = argparse.ArgumentParser(add_help=False)  # avoid conflict with '-h' for height
+    parser = argparse.ArgumentParser()
 
-    parser.add_argument('--mode', choices=_MODES.keys())
+    parser.add_argument('--mode', choices=_MODES.keys(), required=True)
 
     parser.add_argument('-f', '--font', type=str, help='Name of font preset to use - see flap_fonts.scad')
     parser.add_argument('-t', '--text', type=str, help='String of text to generate')
@@ -79,8 +79,6 @@ if __name__ == '__main__':
     parser.add_argument('--kerf', type=float, help='Override kerf_width value')
     parser.add_argument('--fill', action='store_true', help='Fill the text solid (disables optimization)')
     parser.add_argument('--skip-optimize', action='store_true', help='Don\'t remove redundant/overlapping cut lines')
-
-    parser.add_argument("--help", action="help", help="show this help message and exit")
 
     args = parser.parse_args()
 

--- a/3d/scripts/openscad.py
+++ b/3d/scripts/openscad.py
@@ -17,8 +17,15 @@ from __future__ import print_function
 
 import logging
 import numbers
+import os
 import re
 import subprocess
+import sys
+
+repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(repo_root)
+
+from util import app_paths
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +54,7 @@ def run(
         ):
 
     command = [
-        'openscad',
+        app_paths.get('openscad'),
         '-o', output_file,
     ]
 

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -14,12 +14,16 @@
 
 from __future__ import print_function
 from collections import defaultdict
+import os
+try:
+    from svg.path import (
+        Path,
+        Line,
+        parse_path,
+    )
+except:
+    raise RuntimeError(f'Error loading svg.path library. Run "python3 -m pip install -r {os.path.join(os.path.dirname(__file__), "requirements.txt")}" to install it')
 
-from svg.path import (
-    Path,
-    Line,
-    parse_path,
-)
 from xml.dom import minidom
 
 eps = 0.001

--- a/util/app_paths.py
+++ b/util/app_paths.py
@@ -1,0 +1,37 @@
+
+
+import os
+from shutil import which
+from sys import platform
+
+APP_PATH_OVERRIDES = {
+    # If your programs are not found or installed in a non-standard location, add an override
+    # like this:
+    # 'openscad': 'C:\Program Files (x86)\OpenSCAD\openscad.exe'
+}
+
+def get(name):
+    if name in APP_PATH_OVERRIDES:
+        return APP_PATH_OVERRIDES[name]
+
+    if platform == "linux" or platform == "linux2":
+        # Linux: we assume applications are installed on user's PATH
+        _check_path(name, which(name))
+        return which(name)
+    elif platform == "darwin":
+        # OS X
+        raise NotImplementedError('Mac OS is not yet supported')
+    elif platform == "win32":
+        # Windows: check standard locations
+        paths = {
+            'inkscape': 'C:\\Program Files\\Inkscape\\bin\\inkscape.exe',
+            'openscad': 'C:\\Program Files\\OpenSCAD\\openscad.exe',
+        }
+        if name in paths:
+            _check_path(name, paths[name])
+            return paths[name]
+        raise RuntimeError(f'Unknown program {name!r} - please add an entry to {os.path.abspath(__file__)!r}')
+
+def _check_path(name, path):
+    if not os.path.exists(path):
+        raise RuntimeError(f'Expected {name!r} at {path!r}, but it wasn\'t found. If {name!r} is installed in a nonstandard location, add an entry to APP_PATH_OVERRIDES in {os.path.abspath(__file__)!r}')

--- a/util/inkscape.py
+++ b/util/inkscape.py
@@ -1,0 +1,51 @@
+
+import logging
+import re
+import subprocess
+
+import util.app_paths as app_paths
+
+_inkscape_version_cache = None
+
+logger = logging.getLogger(__name__)
+
+def _version():
+    global _inkscape_version_cache
+    if _inkscape_version_cache is not None:
+        return _inkscape_version_cache
+    
+    info = subprocess.check_output([
+        app_paths.get('inkscape'),
+        '--version'
+    ]).decode('utf-8')
+
+    m = re.match(r'Inkscape (\d+\.\d+)', info)
+    _inkscape_version_cache = float(m.group(1))
+    logger.debug(f'Found Inkscape version {_inkscape_version_cache}')
+    return _inkscape_version_cache
+
+def without_gui():
+    if _version() >= 1:
+        """
+        The --without-gui option has been removed. Most parameters trigger Inkscape to run without GUI by default now.
+        Instead enable GUI mode specifically using --with-gui if needed.
+        """
+        return []
+    else:
+        return ['--without-gui']
+
+def _export_filename_v1(filename):
+    assert _version() >= 1
+    return [f'--export-filename={filename}']
+
+def export_png(filename):
+    if _version() >= 1:
+        return _export_filename_v1(filename)
+    else:
+        return ['--export-png', filename]
+
+def export_pdf(filename):
+    if _version() >= 1:
+        return _export_filename_v1(filename)
+    else:
+        return ['--export-pdf', filename]

--- a/util/inkscape.py
+++ b/util/inkscape.py
@@ -1,28 +1,24 @@
 
+from functools import lru_cache
 import logging
 import re
 import subprocess
 
 import util.app_paths as app_paths
 
-_inkscape_version_cache = None
-
 logger = logging.getLogger(__name__)
 
+@lru_cache()
 def _version():
-    global _inkscape_version_cache
-    if _inkscape_version_cache is not None:
-        return _inkscape_version_cache
-    
     info = subprocess.check_output([
         app_paths.get('inkscape'),
         '--version'
     ]).decode('utf-8')
 
     m = re.match(r'Inkscape (\d+\.\d+)', info)
-    _inkscape_version_cache = float(m.group(1))
-    logger.debug(f'Found Inkscape version {_inkscape_version_cache}')
-    return _inkscape_version_cache
+    version = float(m.group(1))
+    logger.debug(f'Found Inkscape version {version}')
+    return version
 
 def without_gui():
     if _version() >= 1:


### PR DESCRIPTION
- Added application executable lookup for Windows and Mac OS where openscad and inkscape don't get added to PATH.
- Added Inkscape argument helpers for CLI arguments that changed in version 1.0
- Added helpful message if `svg.path` python library is missing