### PR TITLE
flap_container.scad: use flap.scad

### DIFF
--- a/3d/tools/flap_container.scad
+++ b/3d/tools/flap_container.scad
@@ -16,6 +16,7 @@
 
 include <../flap_dimensions.scad>
 use <../splitflap.scad>
+use <../flap.scad>
 
 num_flaps = 40;
 containers_x = 1;


### PR DESCRIPTION
Otherwise we get warnings, and things won't render!

```
WARNING: Ignoring unknown module 'flap_2d' in file flap_container.scad, line 76
WARNING: Ignoring unknown module 'flap_2d' in file flap_container.scad, line 118
```