### PR TITLE
Elecrow v2 export fixes

### DIFF
--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -166,14 +166,24 @@ if __name__ == '__main__':
         processor.write(elecrow_svg)
 
         logging.info('Resize SVG canvas')
-        subprocess.check_call([
-            app_paths.get('inkscape'),
-            '--verb=FitCanvasToDrawing',
-            '--verb=FileSave',
-            '--verb=FileClose',
-            '--verb=FileQuit',
-            elecrow_svg,
-        ])
+        # since version 1.2, inkscape has replaced 'verbs' with 'actions'
+        # see: https://wiki.inkscape.org/wiki/Using_the_Command_Line
+        if inkscape._version() < 1.2:
+            subprocess.check_call([
+                app_paths.get('inkscape'),
+                '--verb=FitCanvasToDrawing',
+                '--verb=FileSave',
+                '--verb=FileClose',
+                '--verb=FileQuit',
+                elecrow_svg,
+            ])
+        else:
+            subprocess.check_call([
+                app_paths.get('inkscape'),
+                "--actions=select-all;fit-canvas-to-selection;export-type:svg;export-plain-svg;export-do",
+                elecrow_svg,
+                "-o", elecrow_svg,
+            ])
 
         logging.info('Output PDF')
         subprocess.check_call([

--- a/3d/scripts/generate_2d.py
+++ b/3d/scripts/generate_2d.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
         elecrow_zip = os.path.join(laser_parts_directory, 'elecrow.zip')
 
         processor.apply_elecrow_style()
-        processor.add_dimensions(width_mm, height_mm)
+        processor.add_dimensions(width_mm, height_mm, args.mirror)
         processor.write(elecrow_svg)
 
         logging.info('Resize SVG canvas')

--- a/3d/scripts/svg_processor.py
+++ b/3d/scripts/svg_processor.py
@@ -353,30 +353,31 @@ class SvgProcessor(object):
 
             self.svg_node.appendChild(new_path_node)
 
-    def add_dimensions(self, width_mm, height_mm):
+    def add_dimensions(self, width_mm, height_mm, mirror=False):
         width_node = self.dom.createElement("path")
-        width_node.setAttribute('d', f'M 0 10 l 0 5 l {width_mm} 0 l 0 -5')
+        mirror_dir = -1 if mirror else 1
+        width_node.setAttribute('d', f'M 0 10 l 0 5 l {mirror_dir * width_mm} 0 l 0 -5')
         width_node.setAttribute('fill', 'none')
         width_node.setAttribute('stroke', '#ff00ff')
         width_node.setAttribute('stroke-width', '1')
         self.svg_node.appendChild(width_node)
 
         width_label_node = self.dom.createElement('text')
-        width_label_node.setAttribute('x', f'{width_mm / 2}')
+        width_label_node.setAttribute('x', f'{mirror_dir * width_mm / 2}')
         width_label_node.setAttribute('y', '25')
         width_label_node.setAttribute('style', 'font: 5px sans-serif; fill: #ff00ff; text-anchor: middle;')
         width_label_node.appendChild(self.dom.createTextNode(f'{width_mm:.2f} mm'))
         self.svg_node.appendChild(width_label_node)
 
         height_node = self.dom.createElement("path")
-        height_node.setAttribute('d', f'M -10 0 l -5 0 l 0 -{height_mm} l 5 0')
+        height_node.setAttribute('d', f'M {-width_mm - 10 if mirror else -10} 0 l -5 0 l 0 -{height_mm} l 5 0')
         height_node.setAttribute('fill', 'none')
         height_node.setAttribute('stroke', '#ff00ff')
         height_node.setAttribute('stroke-width', '1')
         self.svg_node.appendChild(height_node)
 
         height_label_node = self.dom.createElement('text')
-        height_label_node.setAttribute('x', '-20')
+        height_label_node.setAttribute('x', f'{-width_mm - 20 if mirror else -20}')
         height_label_node.setAttribute('y', f'{-height_mm / 2}')
         height_label_node.setAttribute('style', 'font: 5px sans-serif; fill: #ff00ff; text-anchor: end;')
         height_label_node.appendChild(self.dom.createTextNode(f'{height_mm:.2f} mm'))


### PR DESCRIPTION
PDFs generated for elecrow on the latest master currently look like this:
![image](https://github.com/scottbez1/splitflap/assets/15990762/8a188939-1e57-4fbf-9400-bb90268b4982)



Dimensions appear to be placed incorrectly when the svg output is mirrored. I updated `add_dimensions` to account for mirroring when its enabled.

I tested this in a 20.04 docker container setup similarly to the actions environment and the output looks correct. Result is below:

[elecrow_dim_fix.pdf](https://github.com/user-attachments/files/15907775/elecrow_dim_fix.pdf)

When testing locally, I also discovered that the inkscape cli has deprecated `--verbs`  in favor of `--actions` in version 1.2+. This PR adds a check to handle both inkscape < 1.2 and >= 1.2 when generating elecrow pdfs