### PR TITLE
Update Python example (and v2 character set) for new features

### DIFF
--- a/arduino/splitflap/Splitflap/config.h
+++ b/arduino/splitflap/Splitflap/config.h
@@ -60,7 +60,7 @@ const uint8_t flaps[NUM_FLAPS] = {
   ' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
   'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
   'Z', 'g', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'r',
-  '.', '?', '-', '$', '\'', '#', 'y', 'p', ',', '!', '~', '&', 'w'
+  '.', '?', '-', '$', '\'', '#', 'y', 'p', ',', '!', '@', '&', 'w'
 };
 
 // Flap option 3: v2 flaps (limited 40-flap set using the first 40 flaps of the set)

--- a/software/chainlink/demo.py
+++ b/software/chainlink/demo.py
@@ -7,10 +7,10 @@ from splitflap_proto import (
 )
 
 words = [
-    'alpaca', 'baboon', 'badger', 'beluga', 'bobcat', 'ferret',
-    'gopher', 'impala', 'jackal', 'jaguar', 'kitten', 'marmot',
-    'monkey', 'ocelot', 'rabbit', 'racoon', 'turtle', 'walrus',
-    'weasel', 'wombat',
+    'ALPACA', 'BABOON', 'BADGER', 'BELUGA', 'BOBCAT', 'FERRET',
+    'GOPHER', 'IMPALA', 'JACKAL', 'JAGUAR', 'KITTEN', 'MARMOT',
+    'MONKEY', 'OCELOT', 'RABBIT', 'RACOON', 'TURTLE', 'WALRUS',
+    'WEASEL', 'WOMBAT',
 ]
 
 

--- a/software/chainlink/splitflap_proto.py
+++ b/software/chainlink/splitflap_proto.py
@@ -42,14 +42,25 @@ class Splitflap(object):
     RETRY_TIMEOUT = 0.25
 
     # TODO: read alphabet from splitflap once this is possible
+
+    # Flap option 1: Legacy Flaps
+    #_DEFAULT_ALPHABET = [
+    #    ' ',
+    #    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    #    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    #    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    #    '.',
+    #    ',',
+    #    '\'',
+    #]
+
+    # Flap option 2: v2 Flaps
     _DEFAULT_ALPHABET = [
         ' ',
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        '.',
-        ',',
-        '\'',
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'g', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'r',
+        '.', '?', '-', '$', '\'', '#', 'y', 'p', ',', '!', '@', '&', 'w',
     ]
 
     def __init__(self, serial_instance):

--- a/software/chainlink/splitflap_proto.py
+++ b/software/chainlink/splitflap_proto.py
@@ -54,7 +54,7 @@ class Splitflap(object):
     #    '\'',
     #]
 
-    # Flap option 2: v2 Flaps
+    # Flap option 2: v2 flaps (52 per module)
     _DEFAULT_ALPHABET = [
         ' ',
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
@@ -62,6 +62,19 @@ class Splitflap(object):
         'g', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'r',
         '.', '?', '-', '$', '\'', '#', 'y', 'p', ',', '!', '@', '&', 'w',
     ]
+
+    # Flap option 3: v2 flaps (limited 40-flap set using the first 40 flaps of the set)
+    #_DEFAULT_ALPHABET = [
+    #    ' ',
+    #    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    #    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    #    'g', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'r', '.',
+    #]
+
+    # Flap option 4: YOUR CUSTOM CHARACTER SET HERE!
+    #_DEFAULT_ALPHABET = [
+    #    <FILL THIS IN!>
+    #]
 
     def __init__(self, serial_instance):
         self._serial = serial_instance


### PR DESCRIPTION
- Replaced `~` with `@` in default v2 character set to match shipped flaps
- Get character set from splitflap display (if possible, otherwise use previous legacy alphabet)
- Use upper case in demo words to match new character sets