### PR TITLE
Implement MQTT topic to set Force Full Rotation

### DIFF
--- a/firmware/esp32/splitflap/secrets.h.example
+++ b/firmware/esp32/splitflap/secrets.h.example
@@ -10,3 +10,4 @@
 #define MQTT_USER "mqttuser"
 #define MQTT_PASSWORD "megasecretpassword"
 #define MQTT_COMMAND_TOPIC "homeassistant/text/splitflap/state"
+#define MQTT_FORCE_FULL_ROTATION_COMMAND_TOPIC "homeassistant/switch/splitflap/state"


### PR DESCRIPTION
This PR allows the user to control the Force Full Rotation setting over MQTT.
By adding a second MQTT control that exposes a switch you can control the Force Full Rotation from for example HomeAssistant.

In HomeAssistant:
![Screenshot 2025-01-30 at 14 35 34](https://github.com/user-attachments/assets/0d070088-c740-4bf3-a9ed-66c1e0fa5589)

Force Full Rotation enabled:

https://github.com/user-attachments/assets/2521fadc-ad59-4fdf-a38f-54cf1f892cf0

Force Full Rotation disabled:

https://github.com/user-attachments/assets/ea7eb246-2499-40b0-9e88-4daf0a05f119

