### PR TITLE
add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.swp
 *.pyc
 build/
+venv
+.venv
 
 # KiCAD files
 *.000


### PR DESCRIPTION
For using generator scripts some non stdlib modules are required. Having the project venv ignored is handy.