### PR TITLE
fix(ci): bump action versions to fix JS workflow

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './software/chainlink/js/packages/example-webserial-basic/build'
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Since 2025-01-30 the JS workflow has been failing with:

    This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
    Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This commit bumps two action versions to repair the workflow.