### PR TITLE
Avoid SPI input glitches from wifi

### DIFF
--- a/firmware/esp32/splitflap/http_task.cpp
+++ b/firmware/esp32/splitflap/http_task.cpp
@@ -234,6 +234,10 @@ HTTPTask::HTTPTask(SplitflapTask& splitflap_task, DisplayTask& display_task, Log
 
 void HTTPTask::connectWifi() {
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+    // Disable WiFi sleep as it causes glitches on pin 39; see https://github.com/espressif/arduino-esp32/issues/4903#issuecomment-793187707
+    WiFi.setSleep(WIFI_PS_NONE);
+    
     char buf[256];
 
     logger_.log("Establishing connection to WiFi..");

--- a/firmware/esp32/splitflap/mqtt_task.cpp
+++ b/firmware/esp32/splitflap/mqtt_task.cpp
@@ -31,6 +31,9 @@ MQTTTask::MQTTTask(SplitflapTask& splitflap_task, Logger& logger, const uint8_t 
 void MQTTTask::connectWifi() {
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
 
+    // Disable WiFi sleep as it causes glitches on pin 39; see https://github.com/espressif/arduino-esp32/issues/4903#issuecomment-793187707
+    WiFi.setSleep(WIFI_PS_NONE);
+
     while (WiFi.status() != WL_CONNECTED) {
         delay(1000);
         logger_.log("Establishing connection to WiFi..");

--- a/firmware/src/spi_io_config.h
+++ b/firmware/src/spi_io_config.h
@@ -75,7 +75,7 @@
   #define BUFFER_ATTRS WORD_ALIGNED_ATTR
 
   // Note: must use HSPI to avoid conflict with ST7789 driver which uses VSPI
-  #define SPI_HOST HSPI_HOST
+  #define SPLITFLAP_SPI_HOST HSPI_HOST
   #define DMA_CHANNEL 1
 
 
@@ -173,7 +173,7 @@ inline void initialize_modules() {
       .quadhd_io_num = -1,
       .max_transfer_sz = 1000,
   };
-  ret=spi_bus_initialize(SPI_HOST, &tx_bus_config, DMA_CHANNEL);
+  ret=spi_bus_initialize(SPLITFLAP_SPI_HOST, &tx_bus_config, DMA_CHANNEL);
   ESP_ERROR_CHECK(ret);
 
   spi_device_interface_config_t tx_device_config = {
@@ -192,7 +192,7 @@ inline void initialize_modules() {
       .pre_cb=NULL,
       .post_cb=NULL,
   };
-  ret=spi_bus_add_device(SPI_HOST, &tx_device_config, &spi_tx);
+  ret=spi_bus_add_device(SPLITFLAP_SPI_HOST, &tx_device_config, &spi_tx);
   ESP_ERROR_CHECK(ret);
 
   spi_device_interface_config_t rx_device_config = {
@@ -211,7 +211,7 @@ inline void initialize_modules() {
       .pre_cb=&latch_registers,
       .post_cb=&reset_latch,
   };
-  ret=spi_bus_add_device(SPI_HOST, &rx_device_config, &spi_rx);
+  ret=spi_bus_add_device(SPLITFLAP_SPI_HOST, &rx_device_config, &spi_rx);
   ESP_ERROR_CHECK(ret);
 
   memset(&tx_transaction, 0, sizeof(tx_transaction));

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,7 @@ lib_deps =
 ;     -DSPLITFLAP_PIO_HARDWARE_CONFIG
 
 [esp32base]
-platform = espressif32@3.4
+platform = espressif32@6.10.0
 framework = arduino
 board = esp32dev
 upload_speed = 921600
@@ -122,7 +122,7 @@ build_flags =
     -DCHAINLINK
     -DNUM_MODULES=6
 
-[env:chainlinkBase]
+[env:advanced_chainlinkBase]
 extends=esp32base
 build_src_filter = ${esp32base.build_src_filter} +<../esp32/base>
 build_flags =
@@ -137,7 +137,7 @@ lib_deps =
     fastled/FastLED @ 3.9.7
     adafruit/Adafruit BusIO @ 1.16.2
 
-[env:chainlinkDriverTester]
+[env:advanced_chainlinkDriverTester]
 extends=esp32base
 build_src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<Splitflap.ino.cpp> +<../esp32/core> +<../esp32/tester>
 build_flags =
@@ -152,7 +152,7 @@ lib_deps =
     adafruit/Adafruit BusIO @ 1.16.2
 build_type = debug
 
-[env:esp32CustomAdvanced]
+[env:advanced_esp32Custom]
 ; For non-chainlink custom ESP32-based advanced builds that use shift registers but omit the Chainlink design elements like loopbacks and LEDs.
 ; This is not the environment you want unless you have custom non-Chainlink hardware and really know the intricacies of the shift register arrangement.
 extends=esp32base


### PR DESCRIPTION
# Changes
* Disable WiFi power saving to avoid sensor data glitches
* Also update platformio espressif platform which was very outdated (note: this may result in a flash rewrite that wipes saved module calibration data!)

# Motivation
* Enabling Wifi previously would cause intermittent "unexpected home" events on arbitrary modules (and sometimes on one of the loopback inputs, causing all modules to be disabled)
* This issue appears related to ESP32 errata 3.11 "When certain RTC peripherals are powered on, the inputs of GPIO36 and GPIO39 will be pulled down for approximately 80ns."
  ![image](https://github.com/user-attachments/assets/8c9982ba-21e4-4b67-9b0a-abfdd8c99edd)
  * Credit to this thread - https://github.com/espressif/arduino-esp32/issues/4903#issuecomment-793442683 - for describing a similar issue and providing a workaround

# Testing
* Correlation with glitches on pin 39 (used as MISO for SPI-based shift-register reads) was identified by probing pin 39 and setting up a trigger on "unexpected home" events
  ![SDS00024](https://github.com/user-attachments/assets/3d1ee549-7260-4e57-afba-5df53413a7ff)
* Glitches were repeatedly seen with a runt trigger on pin 39
* After applying WiFi.setSleep workaround, no more glitches were captured by the runt trigger, and no more "unexpected home" events were seen

